### PR TITLE
Disable command override if a bukkit/forge hybrid is detected.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1699290261
+//version: 1702141377
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -28,27 +28,12 @@ import java.util.concurrent.TimeUnit
 
 buildscript {
     repositories {
-        mavenCentral()
-
-        maven {
-            name 'forge'
-            url 'https://maven.minecraftforge.net'
-        }
         maven {
             // GTNH RetroFuturaGradle and ASM Fork
             name "GTNH Maven"
             url "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
             allowInsecureProtocol = true
         }
-        maven {
-            name 'sonatype'
-            url 'https://oss.sonatype.org/content/repositories/snapshots/'
-        }
-        maven {
-            name 'Scala CI dependencies'
-            url 'https://repo1.maven.org/maven2/'
-        }
-
         mavenLocal()
     }
 }
@@ -69,7 +54,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.24'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.26'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -302,7 +287,7 @@ if (apiPackage) {
 }
 
 if (accessTransformersFile) {
-    for (atFile in accessTransformersFile.split(",")) {
+    for (atFile in accessTransformersFile.split(" ")) {
         String targetFile = "src/main/resources/META-INF/" + atFile.trim()
         if (!getFile(targetFile).exists()) {
             throw new GradleException("Could not resolve \"accessTransformersFile\"! Could not find " + targetFile)
@@ -628,7 +613,7 @@ repositories {
         }
         maven {
             name = "ic2"
-            url = getURL("https://maven.ic2.player.to/", "https://maven2.ic2.player.to/")
+            url = getURL("https://maven2.ic2.player.to/", "https://maven.ic2.player.to/")
             content {
                 includeGroup "net.industrial-craft"
             }
@@ -687,6 +672,8 @@ configurations.all {
         substitute module('com.github.GTNewHorizons:SpongePoweredMixin') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
         substitute module('com.github.GTNewHorizons:SpongeMixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
         substitute module('io.github.legacymoddingmc:unimixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Our previous unimixins upload was missing the dev classifier")
+
+        substitute module('org.scala-lang:scala-library:2.11.1') using module('org.scala-lang:scala-library:2.11.5') because('To allow mixing with Java 8 targets')
     }
 }
 
@@ -793,12 +780,12 @@ ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies"
 }
 
 dependencies {
-    def lwjgl3ifyVersion = '1.5.1'
+    def lwjgl3ifyVersion = '1.5.7'
     if (modId != 'lwjgl3ify') {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.3.17')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.3.35')
     }
 
     java17PatchDependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}:forgePatches") {transitive = false}
@@ -1310,7 +1297,7 @@ def addCurseForgeRelation(String type, String name) {
 
 // Updating
 
-def buildscriptGradleVersion = "8.2.1"
+def buildscriptGradleVersion = "8.5"
 
 tasks.named('wrapper', Wrapper).configure {
     gradleVersion = buildscriptGradleVersion

--- a/src/main/java/serverutils/ServerUtilities.java
+++ b/src/main/java/serverutils/ServerUtilities.java
@@ -18,7 +18,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.SidedProxy;
@@ -134,14 +133,15 @@ public class ServerUtilities {
         if (Ranks.isActive()) {
             Ranks.INSTANCE.commands.clear();
 
-            boolean crucibleLoaded = Loader.isModLoaded("Crucible");
+            boolean bukkitLoaded = CommonUtils.getClassExists("thermos.ThermosRemapper")
+                    || CommonUtils.getClassExists("org.ultramine.server.UltraminePlugin");
 
-            if (crucibleLoaded) {
+            if (bukkitLoaded) {
                 LOGGER.warn(
-                        "Crucible detected, command overriding has been disabled. If there are any issues with Server Utilities ranks or permissions, please test them without Crucible!");
+                        "Thermos/Ultramine detected, command overriding has been disabled. If there are any issues with Server Utilities ranks or permissions, please test them without those mods!");
             }
 
-            if (!ServerUtilitiesConfig.ranks.override_commands || crucibleLoaded) {
+            if (!ServerUtilitiesConfig.ranks.override_commands || bukkitLoaded) {
                 return;
             }
 

--- a/src/main/java/serverutils/ServerUtilities.java
+++ b/src/main/java/serverutils/ServerUtilities.java
@@ -134,7 +134,8 @@ public class ServerUtilities {
             Ranks.INSTANCE.commands.clear();
 
             boolean bukkitLoaded = CommonUtils.getClassExists("thermos.ThermosRemapper")
-                    || CommonUtils.getClassExists("org.ultramine.server.UltraminePlugin");
+                    || CommonUtils.getClassExists("org.ultramine.server.UltraminePlugin")
+                    || CommonUtils.getClassExists("org.bukkit.World");
 
             if (bukkitLoaded) {
                 LOGGER.warn(

--- a/src/main/java/serverutils/lib/util/CommonUtils.java
+++ b/src/main/java/serverutils/lib/util/CommonUtils.java
@@ -38,4 +38,13 @@ public class CommonUtils {
         String pkg = clazz.getName().substring(0, clazz.getName().lastIndexOf('.'));
         return packageOwners.containsKey(pkg) ? packageOwners.get(pkg).get(0) : null;
     }
+
+    public static boolean getClassExists(String className) {
+        try {
+            Class.forName(className, false, CommonUtils.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
Command override is very incompatible with bukkit and a plugin should be used to handle command permission instead. 

This disables the feature for Crucible, Thermos and hopefully Ultramine. I was only able to find the source for [Ultramine 1.8](https://github.com/TechCatOther/ultramine_core) so lets hope the classpath hasn't changed.

Closes: https://github.com/GTNewHorizons/ServerUtilities/issues/12