### PR TITLE
Add synced Wiki

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -2,19 +2,18 @@ on:
     push:
         branches:
             - master
-    pull_request:
-        branches:
-            - master
 name: Wiki Sync
 jobs:
     update-wiki:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@master
+          - uses: actions/checkout@v4
           - name: Sync Wiki
-            uses: joeizzard/action-wiki-sync@master
+            uses: GTNewHorizons/ghaction-wiki-sync@master
             with:
-                username: ${{ github.event.pusher.name }}
+                username: "GitHub-GTNH-Actions"
                 access_token: ${{ secrets.GITHUB_TOKEN }}
-                commit_username: ${{ github.event.pusher.name }}
-                commit_email: ${{ github.event.pusher.email }}
+                ignore_safe_warnings: true
+                commit_username: "GitHub GTNH Actions"
+                commit_email: "<>"
+                commit_message: "automatic wiki sync: ${{ github.event.commits[0].message }}"

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,20 @@
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+        branches:
+            - master
+name: Wiki Sync
+jobs:
+    update-wiki:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@master
+          - name: Sync Wiki
+            uses: joeizzard/action-wiki-sync@master
+            with:
+                username: ${{ github.event.pusher.name }}
+                access_token: ${{ secrets.GITHUB_TOKEN }}
+                commit_username: ${{ github.event.pusher.name }}
+                commit_email: ${{ github.event.pusher.email }}

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,1 @@
+Welcome to the ServerUtilities wiki!

--- a/wiki/Quick-Install.md
+++ b/wiki/Quick-Install.md
@@ -1,0 +1,11 @@
+Download the latest JAR from [releases](https://github.com/GTNewHorizons/ServerUtilities/releases) - you want the one named ServerUtilities-number.jar, not the `dev` or `sources`. Place it in the `/mods` folder on your server AND client (if single player, on client only).
+
+Once loaded, you will find new UI options in your inventory screen:
+
+![ServerUtilities GUI](claimed_chunks.png)
+
+For single player, loading chunks is the most important, and you can click that icon and then shift-click (and drag) to designate chunks to load. Right click to unload and unclaim.
+
+The ServerUtilities configuration files are found in `.minecraft/serverutilities` and it will migrate from FTBU for you. The most likely thing you want to change is found in `.minecraft/serverutilties/server/ranks.txt` where you can control how many chunks can be loaded. `.minecraft/serverutilities/serverutlities.cfg` is where you can disable backups if you have another backup solution.
+
+For server admins, there is much more that ServerUtilities can do, refer to the FTBU documentation for now.


### PR DESCRIPTION
Depends on https://github.com/GTNewHorizons/ghaction-wiki-sync/pull/1.

While GitHub wikis are repositories which can be cloned, they don't have a web interface like normal repos and [don't support PRs](https://stackoverflow.com/a/11481887/). Thus, external people can't contribute to the wiki. This workflow syncs the files from `./wiki/`, combining the ease of working with a normal repositories with the benefits of the better UI of wikis.

I included the [Quick Install](https://github.com/GTNewHorizons/ServerUtilities#quick-install) section of the README as a starting point.