### PR TITLE
Add config option to have side buttons drawn vertically

### DIFF
--- a/src/main/java/serverutils/client/EnumSidebarButtonPlacement.java
+++ b/src/main/java/serverutils/client/EnumSidebarButtonPlacement.java
@@ -22,8 +22,13 @@ public enum EnumSidebarButtonPlacement {
     }
 
     public boolean above() {
-        return this == AUTO && !Minecraft.getMinecraft().thePlayer.getActivePotionEffects().isEmpty()
+        return (this == AUTO || this == INVENTORY_SIDE)
+                && !Minecraft.getMinecraft().thePlayer.getActivePotionEffects().isEmpty()
                 && ServerUtilitiesClientConfig.sidebar_buttons_above_potion;
+    }
+
+    public boolean vertical() {
+        return (this == AUTO || this == INVENTORY_SIDE) && ServerUtilitiesClientConfig.sidebar_buttons_vertical;
     }
 
     public static EnumSidebarButtonPlacement string2placement(String placement) {

--- a/src/main/java/serverutils/client/ServerUtilitiesClientConfig.java
+++ b/src/main/java/serverutils/client/ServerUtilitiesClientConfig.java
@@ -53,12 +53,20 @@ public class ServerUtilitiesClientConfig {
                         DISABLED: Disable non-important notifications entirely.""")
                         .setLanguageKey(CLIENT_LANG_KEY + "notification_location")
                         .setValidValues(notification_locations).getString());
-        sidebar_buttons_above_potion = config.get(
-                Configuration.CATEGORY_GENERAL,
-                "sidebar_buttons_above_potion",
-                false,
-                "Move buttons above potion effect label whenever an effect is active and placement is set to AUTO.")
+        sidebar_buttons_above_potion = config
+                .get(
+                        Configuration.CATEGORY_GENERAL,
+                        "sidebar_buttons_above_potion",
+                        false,
+                        "Move buttons above potion effect label whenever an effect is active.")
                 .setLanguageKey(CLIENT_LANG_KEY + "sidebar_buttons_above_potion").getBoolean();
+        sidebar_buttons_vertical = config
+                .get(
+                        Configuration.CATEGORY_GENERAL,
+                        "sidebar_buttons_vertical",
+                        false,
+                        "Draw sidebar buttons in a vertical line.")
+                .setLanguageKey(CLIENT_LANG_KEY + "sidebar_buttons_vertical").getBoolean();
         show_dotted_lines = config
                 .get(
                         Configuration.CATEGORY_GENERAL,
@@ -105,6 +113,7 @@ public class ServerUtilitiesClientConfig {
     public static boolean item_nbt;
     public static EnumSidebarButtonPlacement sidebar_buttons;
     public static boolean sidebar_buttons_above_potion;
+    public static boolean sidebar_buttons_vertical;
     public static String[] sidebar_buttons_locations = { "DISABLED", "TOP_LEFT", "INVENTORY_SIDE", "AUTO" };
     public static EnumNotificationLocation notifications;
     public static String[] notification_locations = { "SCREEN", "CHAT", "DISABLED" };

--- a/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
@@ -492,6 +492,7 @@ public class ServerUtilitiesClientEventHandler {
             boolean addedAny;
             boolean top = ServerUtilitiesClientConfig.sidebar_buttons.top();
             boolean above = ServerUtilitiesClientConfig.sidebar_buttons.above();
+            boolean vertical = ServerUtilitiesClientConfig.sidebar_buttons.vertical();
 
             for (SidebarButtonGroup group : SidebarButtonManager.INSTANCE.groups) {
                 if (above && !isCreativePlusGui(gui)) {
@@ -504,6 +505,17 @@ public class ServerUtilitiesClientEventHandler {
                             if (ry >= 7) {
                                 ry = 0;
                                 rx--;
+                            }
+                        }
+                    }
+                } else if (vertical) {
+                    for (SidebarButton button : group.getButtons()) {
+                        if (button.isActuallyVisible()) {
+                            buttons.add(new GuiButtonSidebar(rx, ry, button));
+                            rx++;
+                            if (rx >= 9) {
+                                rx = 0;
+                                ry++;
                             }
                         }
                     }

--- a/src/main/resources/assets/serverutilities/lang/en_US.lang
+++ b/src/main/resources/assets/serverutilities/lang/en_US.lang
@@ -173,6 +173,7 @@ serverutilities_client.item_ore_names.item_tooltip=Ore Dictionary Names:
 serverutilities_client.item_nbt=Display Item NBT
 serverutilities_client.sidebar_buttons=Sidebar Button Location
 serverutilities_client.sidebar_buttons_above_potion=Draw Buttons Above Potion Label
+serverutilities_client.sidebar_buttons_vertical=Draw Buttons Vertically
 serverutilities_client.notification_location=Notification Location
 serverutilities_client.show_dotted_lines=Show Dotted Line On Loaded Chunks
 


### PR DESCRIPTION
Closes: https://github.com/GTNewHorizons/ServerUtilities/issues/27

![vertical](https://github.com/GTNewHorizons/ServerUtilities/assets/127234178/807a6f29-2f90-4c35-9738-61a95d2c293f)

Moves over one row after 9 buttons in order to not draw past the inventory height

![all_buttons](https://github.com/GTNewHorizons/ServerUtilities/assets/127234178/d4a8b9b5-ce88-487c-a6d7-c0e1eb6d6eab)
