### PR TITLE
Add null check for CommandOverride

### DIFF
--- a/src/main/java/serverutils/ranks/CommandOverride.java
+++ b/src/main/java/serverutils/ranks/CommandOverride.java
@@ -52,12 +52,12 @@ public class CommandOverride extends CommandBase {
 
     @Override
     public String getCommandName() {
-        return mirrored.getCommandName();
+        return mirrored.getCommandName() == null ? "" : mirrored.getCommandName();
     }
 
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return mirrored.getCommandUsage(sender);
+        return mirrored.getCommandUsage(sender) == null ? "" : mirrored.getCommandUsage(sender);
     }
 
     @Override


### PR DESCRIPTION
It seems that HelpFixer doesn't work when the command is overwritten. Adding a null check in CommandOverride fixes the issue.

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15264
Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15145