### PR TITLE
Fix /backup start counting as automatic backup when ran from console

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 
 dependencies {
 
-    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.5.4-GTNH:dev")
+    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.5.17-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:VisualProspecting:1.2.6:dev")
     compileOnly("com.github.GTNewHorizons:EnderIO:2.6.4:dev")
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.9'
 }
 
 

--- a/src/main/java/serverutils/backups/Backups.java
+++ b/src/main/java/serverutils/backups/Backups.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.command.ICommandSender;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.WorldServer;
 
@@ -36,7 +35,7 @@ public class Backups {
 
     public static boolean run(ICommandSender ics, String customName) {
         if (thread != null) return false;
-        boolean auto = !(ics instanceof EntityPlayerMP);
+        boolean auto = ics == null;
 
         if (auto && !ServerUtilitiesConfig.backups.enable_backups) return false;
 
@@ -47,7 +46,7 @@ public class Backups {
             if (!hasOnlinePlayers() && !hadPlayer) return true;
             hadPlayer = false;
         }
-        ServerUtilitiesNotifications.backupNotification(BACKUP_START, "cmd.backup_start", ics.getCommandSenderName());
+        ServerUtilitiesNotifications.backupNotification(BACKUP_START, "cmd.backup_start");
 
         try {
             for (int i = 0; i < server.worldServers.length; ++i) {

--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -233,7 +233,7 @@ public class ServerUtilitiesServerEventHandler {
             }
 
             if (Backups.nextBackup > 0L && Backups.nextBackup <= now) {
-                Backups.run(universe.server, "");
+                Backups.run(null, "");
             }
 
             if (Backups.thread != null && Backups.thread.isDone) {


### PR DESCRIPTION
Ics is only used to check whether it's an automatic backup or manual. Before only EntityPlayerMP's would count as manual, instead we just null it when it's an automatic backup and anything not null is now considered manual.

Closes: https://github.com/GTNewHorizons/ServerUtilities/issues/33