### PR TITLE
 Convert TP warmup countdown to notification

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesNotifications.java
+++ b/src/main/java/serverutils/ServerUtilitiesNotifications.java
@@ -27,6 +27,9 @@ public class ServerUtilitiesNotifications {
             "cant_claim_chunk");
     public static final ResourceLocation UNCLAIMED_ALL = new ResourceLocation(ServerUtilities.MOD_ID, "unclaimed_all");
     public static final ResourceLocation TELEPORT = new ResourceLocation(ServerUtilities.MOD_ID, "teleport");
+    public static final ResourceLocation TELEPORT_WARMUP = new ResourceLocation(
+            ServerUtilities.MOD_ID,
+            "teleport_warmup");
     public static final ResourceLocation RELOAD_SERVER = new ResourceLocation(ServerUtilities.MOD_ID, "reload_server");
     public static final ResourceLocation BACKUP_START = new ResourceLocation(ServerUtilities.MOD_ID, "backup_start");
     public static final ResourceLocation BACKUP_END1 = new ResourceLocation(ServerUtilities.MOD_ID, "backup_end1");

--- a/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
@@ -235,6 +235,12 @@ public class ServerUtilitiesClientEventHandler {
             Minecraft.getMinecraft().thePlayer.addChatMessage(component);
         } else if (component instanceof Notification notification) {
             ResourceLocation id = notification.getId();
+
+            if (notification.isVanilla()) {
+                Minecraft.getMinecraft().ingameGUI.func_110326_a(component.getFormattedText(), false);
+                return;
+            }
+
             Temp.MAP.remove(id);
             if (currentNotification != null && currentNotification.widget.id.equals(id)) {
                 currentNotification = null;

--- a/src/main/java/serverutils/lib/util/JsonUtils.java
+++ b/src/main/java/serverutils/lib/util/JsonUtils.java
@@ -235,6 +235,10 @@ public class JsonUtils {
                 if (n.isImportant()) {
                     json.addProperty("important", true);
                 }
+
+                if (n.isVanilla()) {
+                    json.addProperty("vanilla", true);
+                }
             }
         } else if (component instanceof ChatComponentTranslation translation) {
             json.addProperty("translate", translation.getKey());
@@ -296,7 +300,7 @@ public class JsonUtils {
             if (json.has("text") || json.has("notification")) {
                 String s = json.has("text") ? StringUtils.fixTabs(json.get("text").getAsString(), 2) : "";
 
-                if (json.has("notification") || json.has("timer") || json.has("important")) {
+                if (json.has("notification") || json.has("timer") || json.has("important") || json.has("vanilla")) {
                     Notification n = Notification.of(
                             json.has("notification") ? new ResourceLocation(json.get("notification").getAsString())
                                     : Notification.VANILLA_STATUS,
@@ -315,6 +319,10 @@ public class JsonUtils {
 
                     if (json.has("important")) {
                         n.setImportant(net.minecraft.util.JsonUtils.getJsonObjectBooleanFieldValue(json, "important"));
+                    }
+
+                    if (json.has("vanilla")) {
+                        n.setVanilla(net.minecraft.util.JsonUtils.getJsonObjectBooleanFieldValue(json, "vanilla"));
                     }
                 } else if (json.has("countdown")) {
                     component = new TextComponentCountdown(s, json.get("countdown").getAsLong());

--- a/src/main/java/serverutils/lib/util/text_components/Notification.java
+++ b/src/main/java/serverutils/lib/util/text_components/Notification.java
@@ -35,12 +35,14 @@ public class Notification extends ChatComponentText {
     private final ResourceLocation id;
     private Ticks timer;
     private boolean important;
+    private boolean vanilla;
 
     private Notification(ResourceLocation i, String text) {
         super(text);
         id = i;
         timer = Ticks.SECOND.x(3);
         important = false;
+        vanilla = false;
     }
 
     public Notification(Notification n) {
@@ -54,6 +56,7 @@ public class Notification extends ChatComponentText {
 
         setTimer(n.getTimer());
         setImportant(n.isImportant());
+        setVanilla(n.isVanilla());
     }
 
     public Notification addLine(IChatComponent line) {
@@ -116,8 +119,17 @@ public class Notification extends ChatComponentText {
         return important;
     }
 
+    public boolean isVanilla() {
+        return vanilla;
+    }
+
     public Notification setImportant(boolean v) {
         important = v;
+        return this;
+    }
+
+    public Notification setVanilla(boolean v) {
+        vanilla = v;
         return this;
     }
 


### PR DESCRIPTION
Addresses this comment: https://github.com/GTNewHorizons/ServerUtilities/issues/32#issuecomment-1933110550

Our current notification implementation makes notifications fade out when replaced by another one, which works great normally but looks headache inducing for a countdown. 
Because of that I implemented a way to send notifications the vanilla way (like the jukebox). This works better for a countdown as it will stay persistently on screen whilst counting down. 

Chat spam begone!

![warmup_noti](https://github.com/GTNewHorizons/ServerUtilities/assets/127234178/8410fbad-025e-411c-9bd0-e61bd8e54973)
