### PR TITLE
Better fix for disappearing buttons

### DIFF
--- a/src/main/java/serverutils/ServerUtilities.java
+++ b/src/main/java/serverutils/ServerUtilities.java
@@ -51,7 +51,6 @@ import serverutils.ranks.Ranks;
         modid = ServerUtilities.MOD_ID,
         name = ServerUtilities.MOD_NAME,
         version = ServerUtilities.VERSION,
-        acceptableRemoteVersions = "*",
         dependencies = "after:visualprospecting;",
         guiFactory = "serverutils.client.gui.GuiFactory")
 public class ServerUtilities {
@@ -184,7 +183,6 @@ public class ServerUtilities {
 
     @NetworkCheckHandler
     public boolean checkModLists(Map<String, String> map, Side side) {
-        SidedUtils.checkModLists(side, map);
-        return true;
+        return side != Side.CLIENT || map.containsKey(MOD_ID) && map.get(MOD_ID).equals(VERSION);
     }
 }

--- a/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
@@ -110,11 +110,6 @@ public class ServerUtilitiesClientEventHandler {
     }
 
     @SubscribeEvent
-    public void onClientConnected(FMLNetworkEvent.ClientConnectedToServerEvent event) {
-        SidedUtils.SERVER_MODS.putAll(SidedUtils.SERVER_MODS_0);
-    }
-
-    @SubscribeEvent
     public void onClientWorldTick(TickEvent.ClientTickEvent event) {
         Minecraft mc = Minecraft.getMinecraft();
 

--- a/src/main/java/serverutils/lib/util/SidedUtils.java
+++ b/src/main/java/serverutils/lib/util/SidedUtils.java
@@ -13,15 +13,9 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.IChatComponent;
 
-import cpw.mods.fml.relauncher.Side;
-import serverutils.ServerUtilities;
-import serverutils.ServerUtilitiesConfig;
-
 public class SidedUtils {
 
-    public static final Map<String, String> SERVER_MODS_0 = new HashMap<>();
     public static Map<String, String> SERVER_MODS = new HashMap<>();
-
     public static UUID UNIVERSE_UUID_CLIENT = null;
 
     public static IChatComponent lang(@Nullable ICommandSender sender, String mod, String key, Object... args) {
@@ -29,18 +23,6 @@ public class SidedUtils {
             return new ChatComponentText(I18n.format(key, args));
         }
         return new ChatComponentTranslation(key, args);
-    }
-
-    public static void checkModLists(@Nullable Side side, @Nullable Map<String, String> map) {
-        if (side == Side.SERVER) {
-            if (map != null && !map.isEmpty()) {
-                SERVER_MODS_0.clear();
-                SERVER_MODS_0.putAll(map);
-                if (ServerUtilitiesConfig.debugging.print_more_info) {
-                    ServerUtilities.LOGGER.info("Received Map for mod check: " + map);
-                }
-            }
-        } else if (side == Side.CLIENT) {}
     }
 
     /**


### PR DESCRIPTION
Closes: https://github.com/GTNewHorizons/ServerUtilities/issues/28

NetworkCheckHandler is apparently inconsistent and at times keeps sending mod lists from other servers while the client is connecting as seen in this [log](https://pastebin.ubuntu.com/p/yqp9H52Wzw/). 
Instead of relying on that we send the mod list with MessageSyncData, which is sent to the player upon connecting.

To prevent any potential problems the server now requires the client to have the same mod version. No mod rejection is performed client-side so players will still be able to join servers without the mod.
