### PR TITLE
Add ability to claim chunks from JourneyMap

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,11 +3,11 @@
 dependencies {
 
     compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.5.17-GTNH:dev")
-    compileOnly("com.github.GTNewHorizons:VisualProspecting:1.2.6:dev")
+    compileOnly("com.github.GTNewHorizons:VisualProspecting:1.2.9:dev")
     compileOnly("com.github.GTNewHorizons:EnderIO:2.6.4:dev")
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:waila:1.7.0:dev")
-//    runtimeOnlyNonPublishable("com.github.GTNewHorizons:VisualProspecting:1.2.6:dev")
+//    runtimeOnlyNonPublishable("com.github.GTNewHorizons:VisualProspecting:1.2.9:dev")
 
     shadowCompile("it.unimi.dsi:fastutil:8.5.12")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.12'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
 }
 
 

--- a/src/main/java/serverutils/client/gui/ClientClaimedChunks.java
+++ b/src/main/java/serverutils/client/gui/ClientClaimedChunks.java
@@ -65,7 +65,7 @@ public class ClientClaimedChunks {
         public static final int LOADED = 1;
 
         public final Team team;
-        public final int flags;
+        private int flags;
 
         public ChunkData(Team t, int f) {
             team = t;
@@ -88,6 +88,19 @@ public class ClientClaimedChunks {
 
         public boolean isLoaded() {
             return Bits.getFlag(flags, LOADED);
+        }
+
+        public ChunkData setLoaded(boolean value) {
+            flags = Bits.setFlag(flags, LOADED, value);
+            return this;
+        }
+
+        public ChunkData copy() {
+            return new ChunkData(team, flags);
+        }
+
+        public int getFlags() {
+            return flags;
         }
     }
 }

--- a/src/main/java/serverutils/client/gui/GuiClaimedChunks.java
+++ b/src/main/java/serverutils/client/gui/GuiClaimedChunks.java
@@ -62,7 +62,7 @@ public class GuiClaimedChunks extends GuiChunkSelectorBase {
             with = NULL_CHUNK_DATA;
         }
 
-        return (data.flags != with.flags || data.team != with.team) && !with.isLoaded();
+        return (data.getFlags() != with.getFlags() || data.team != with.team) && !with.isLoaded();
     }
 
     @Override

--- a/src/main/java/serverutils/client/gui/GuiClaimedChunks.java
+++ b/src/main/java/serverutils/client/gui/GuiClaimedChunks.java
@@ -16,7 +16,6 @@ import net.minecraft.world.ChunkCoordIntPair;
 import org.lwjgl.opengl.GL11;
 
 import serverutils.client.ServerUtilitiesClientConfig;
-import serverutils.events.chunks.UpdateClientDataEvent;
 import serverutils.lib.EnumTeamColor;
 import serverutils.lib.client.CachedVertexData;
 import serverutils.lib.client.ClientUtils;
@@ -71,8 +70,7 @@ public class GuiClaimedChunks extends GuiChunkSelectorBase {
         ChunkSelectorMap.getMap().resetMap(startX, startZ);
     }
 
-    public static void onChunkDataUpdate(UpdateClientDataEvent event) {
-        MessageClaimedChunksUpdate m = event.getMessage();
+    public static void onChunkDataUpdate(MessageClaimedChunksUpdate m) {
         claimedChunks = m.claimedChunks;
         loadedChunks = m.loadedChunks;
         maxClaimedChunks = m.maxClaimedChunks;

--- a/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
@@ -65,6 +65,7 @@ import serverutils.lib.util.SidedUtils;
 import serverutils.lib.util.StringUtils;
 import serverutils.lib.util.text_components.Notification;
 import serverutils.net.MessageAdminPanelGui;
+import serverutils.net.MessageClaimedChunksUpdate;
 import serverutils.net.MessageEditNBTRequest;
 import serverutils.net.MessageLeaderboardList;
 import serverutils.net.MessageMyTeamGui;
@@ -129,7 +130,11 @@ public class ServerUtilitiesClientEventHandler {
 
     @SubscribeEvent
     public void onChunkDataUpdate(UpdateClientDataEvent event) {
-        GuiClaimedChunks.onChunkDataUpdate(event);
+        MessageClaimedChunksUpdate message = event.getMessage();
+        GuiClaimedChunks.onChunkDataUpdate(message);
+        if (OtherMods.isVPLoaded()) {
+            VPIntegration.onChunkDataUpdate(message);
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/serverutils/integration/vp/VPClaimsLocation.java
+++ b/src/main/java/serverutils/integration/vp/VPClaimsLocation.java
@@ -84,6 +84,10 @@ public class VPClaimsLocation implements IWaypointAndLocationProvider {
         }
     }
 
+    public String claimHint() {
+        return EnumChatFormatting.DARK_GRAY + I18n.format("serverutilities.jm.claim");
+    }
+
     public String toggleLoadHint() {
         return EnumChatFormatting.DARK_GRAY + I18n.format("serverutilities.jm.load_hint");
     }

--- a/src/main/java/serverutils/integration/vp/VPIntegration.java
+++ b/src/main/java/serverutils/integration/vp/VPIntegration.java
@@ -8,12 +8,14 @@ import serverutils.client.gui.ClientClaimedChunks;
 import serverutils.integration.vp.journeymap.VPClaimsRenderer;
 import serverutils.integration.vp.journeymap.VPLayerButton;
 import serverutils.lib.math.ChunkDimPos;
+import serverutils.net.MessageClaimedChunksUpdate;
 import serverutils.net.MessageJourneyMapUpdate;
 
 public class VPIntegration {
 
     public static final Object2ObjectMap<ChunkDimPos, ClientClaimedChunks.ChunkData> CLAIMS = new Object2ObjectOpenHashMap<>();
     public static ClientClaimedChunks.ChunkData OWNTEAM = null;
+    public static int maxClaimedChunks, currentClaimedChunks;
 
     public static void init() {
         VisualProspecting_API.LogicalClient.registerCustomButtonManager(VPButtonManager.INSTANCE);
@@ -34,8 +36,14 @@ public class VPIntegration {
 
     public static void addToOwnTeam(ChunkDimPos pos) {
         if (OWNTEAM == null) return;
+        if (currentClaimedChunks >= maxClaimedChunks) return;
 
         CLAIMS.put(pos, OWNTEAM);
         VPLayerManager.INSTANCE.forceRefresh();
+    }
+
+    public static void onChunkDataUpdate(MessageClaimedChunksUpdate message) {
+        maxClaimedChunks = message.maxClaimedChunks;
+        currentClaimedChunks = message.claimedChunks;
     }
 }

--- a/src/main/java/serverutils/integration/vp/VPIntegration.java
+++ b/src/main/java/serverutils/integration/vp/VPIntegration.java
@@ -13,6 +13,7 @@ import serverutils.net.MessageJourneyMapUpdate;
 public class VPIntegration {
 
     public static final Object2ObjectMap<ChunkDimPos, ClientClaimedChunks.ChunkData> CLAIMS = new Object2ObjectOpenHashMap<>();
+    public static ClientClaimedChunks.ChunkData OWNTEAM = null;
 
     public static void init() {
         VisualProspecting_API.LogicalClient.registerCustomButtonManager(VPButtonManager.INSTANCE);
@@ -24,7 +25,22 @@ public class VPIntegration {
     public static void updateMap(MessageJourneyMapUpdate message) {
         for (ClientClaimedChunks.Team team : message.teams.values()) {
             CLAIMS.putAll(team.chunkPos);
+            if (OWNTEAM == null && team.isMember) {
+                for (ClientClaimedChunks.ChunkData chunkData : team.chunkPos.values()) {
+                    if (!chunkData.isLoaded()) {
+                        OWNTEAM = chunkData;
+                        break;
+                    }
+                }
+            }
         }
+        VPLayerManager.INSTANCE.forceRefresh();
+    }
+
+    public static void addToOwnTeam(ChunkDimPos pos) {
+        if (OWNTEAM == null) return;
+
+        CLAIMS.put(pos, OWNTEAM);
         VPLayerManager.INSTANCE.forceRefresh();
     }
 }

--- a/src/main/java/serverutils/integration/vp/VPIntegration.java
+++ b/src/main/java/serverutils/integration/vp/VPIntegration.java
@@ -26,12 +26,7 @@ public class VPIntegration {
         for (ClientClaimedChunks.Team team : message.teams.values()) {
             CLAIMS.putAll(team.chunkPos);
             if (OWNTEAM == null && team.isMember) {
-                for (ClientClaimedChunks.ChunkData chunkData : team.chunkPos.values()) {
-                    if (!chunkData.isLoaded()) {
-                        OWNTEAM = chunkData;
-                        break;
-                    }
-                }
+                OWNTEAM = team.chunkPos.values().iterator().next().copy().setLoaded(false);
             }
         }
         VPLayerManager.INSTANCE.forceRefresh();

--- a/src/main/java/serverutils/integration/vp/VPLayerManager.java
+++ b/src/main/java/serverutils/integration/vp/VPLayerManager.java
@@ -45,7 +45,12 @@ public class VPLayerManager extends WaypointProviderManager {
         Collection<ChunkCoordIntPair> chunk = Collections.singleton(new ChunkCoordIntPair(chunkX, chunkZ));
         ChunkDimPos chunkDimPos = new ChunkDimPos(chunkX, chunkZ, mc.thePlayer.dimension);
         new MessageClaimedChunksModify(chunkX, chunkZ, selectionMode, chunk).sendToServer();
-        VPIntegration.addToOwnTeam(chunkDimPos);
+
+        if(VPIntegration.OWNTEAM == null){
+            new MessageJourneyMapRequest(blockX, blockX, blockZ, blockZ).sendToServer();
+        }else{
+            VPIntegration.addToOwnTeam(chunkDimPos);
+        }
         return true;
     }
 

--- a/src/main/java/serverutils/integration/vp/VPLayerManager.java
+++ b/src/main/java/serverutils/integration/vp/VPLayerManager.java
@@ -1,19 +1,24 @@
 package serverutils.integration.vp;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
+import net.minecraft.world.ChunkCoordIntPair;
 
 import com.sinthoras.visualprospecting.Utils;
 import com.sinthoras.visualprospecting.integration.model.layers.WaypointProviderManager;
 import com.sinthoras.visualprospecting.integration.model.locations.IWaypointAndLocationProvider;
 
+import journeymap.client.model.BlockCoordIntPair;
 import serverutils.client.gui.ClientClaimedChunks;
 import serverutils.lib.math.ChunkDimPos;
+import serverutils.net.MessageClaimedChunksModify;
 import serverutils.net.MessageJourneyMapRequest;
 
 public class VPLayerManager extends WaypointProviderManager {
@@ -27,6 +32,21 @@ public class VPLayerManager extends WaypointProviderManager {
 
     public VPLayerManager() {
         super(VPButtonManager.INSTANCE);
+    }
+
+    @Override
+    public boolean doActionOutsideLayer(BlockCoordIntPair blockCoord) {
+        Minecraft mc = Minecraft.getMinecraft();
+        int selectionMode = MessageClaimedChunksModify.CLAIM;
+        int blockX = blockCoord.x;
+        int blockZ = blockCoord.z;
+        int chunkX = Utils.coordBlockToChunk(blockX);
+        int chunkZ = Utils.coordBlockToChunk(blockZ);
+        Collection<ChunkCoordIntPair> chunk = Collections.singleton(new ChunkCoordIntPair(chunkX, chunkZ));
+        ChunkDimPos chunkDimPos = new ChunkDimPos(chunkX, chunkZ, mc.thePlayer.dimension);
+        new MessageClaimedChunksModify(chunkX, chunkZ, selectionMode, chunk).sendToServer();
+        VPIntegration.addToOwnTeam(chunkDimPos);
+        return true;
     }
 
     @Override

--- a/src/main/java/serverutils/integration/vp/VPLayerManager.java
+++ b/src/main/java/serverutils/integration/vp/VPLayerManager.java
@@ -46,9 +46,9 @@ public class VPLayerManager extends WaypointProviderManager {
         ChunkDimPos chunkDimPos = new ChunkDimPos(chunkX, chunkZ, mc.thePlayer.dimension);
         new MessageClaimedChunksModify(chunkX, chunkZ, selectionMode, chunk).sendToServer();
 
-        if(VPIntegration.OWNTEAM == null){
+        if (VPIntegration.OWNTEAM == null) {
             new MessageJourneyMapRequest(blockX, blockX, blockZ, blockZ).sendToServer();
-        }else{
+        } else {
             VPIntegration.addToOwnTeam(chunkDimPos);
         }
         return true;

--- a/src/main/java/serverutils/integration/vp/journeymap/VPDrawStep.java
+++ b/src/main/java/serverutils/integration/vp/journeymap/VPDrawStep.java
@@ -62,6 +62,7 @@ public class VPDrawStep implements ClickableDrawStep {
             tooltip.add(location.loadedHint());
         }
         if (location.getOwnTeam()) {
+            tooltip.add(location.claimHint());
             tooltip.add(location.toggleLoadHint());
             tooltip.add(location.unclaimHint());
         }

--- a/src/main/resources/assets/serverutilities/lang/en_US.lang
+++ b/src/main/resources/assets/serverutilities/lang/en_US.lang
@@ -625,5 +625,6 @@ aurora.port=Port
 
 # JourneyMap
 serverutilities.jm.own_team=Your Team
-serverutilities.jm.load_hint=Double click to load/unload
+serverutilities.jm.claim=Double click an empty chunk to claim.
+serverutilities.jm.load_hint=Double click a claimed chunk to load/unload
 serverutilities.jm.unclaim_hint=Press %s to unclaim


### PR DESCRIPTION
Depends on: https://github.com/GTNewHorizons/VisualProspecting/pull/43

Enables players to claim chunks by double clicking them on jmap (with the SU layer active).

There is a slight delay between us claiming the chunk and the server processing it. Because of that requesting that chunk through a packet immediately after claiming will often result in nothing. 
The chunk does get claimed though, so we hijack the chunk data from any of the players team's chunks and add that along with the chunk position to the map. If no chunk data is available we fall back to requesting it through a packet.