### PR TITLE
Creating a `/homes` command

### DIFF
--- a/src/main/java/serverutils/command/ServerUtilitiesCommands.java
+++ b/src/main/java/serverutils/command/ServerUtilitiesCommands.java
@@ -8,6 +8,7 @@ import serverutils.command.tp.CmdBack;
 import serverutils.command.tp.CmdDelHome;
 import serverutils.command.tp.CmdDelWarp;
 import serverutils.command.tp.CmdHome;
+import serverutils.command.tp.CmdHomes;
 import serverutils.command.tp.CmdRTP;
 import serverutils.command.tp.CmdSetHome;
 import serverutils.command.tp.CmdSetWarp;
@@ -41,6 +42,7 @@ public class ServerUtilitiesCommands {
         if (ServerUtilitiesConfig.commands.home) {
             event.registerServerCommand(new CmdHome());
             event.registerServerCommand(new CmdSetHome());
+            event.registerServerCommand(new CmdHomes());
             event.registerServerCommand(new CmdDelHome());
         }
 

--- a/src/main/java/serverutils/command/tp/CmdHomes.java
+++ b/src/main/java/serverutils/command/tp/CmdHomes.java
@@ -1,0 +1,42 @@
+package serverutils.command.tp;
+
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.ChatComponentText;
+import serverutils.ServerUtilities;
+import serverutils.data.ServerUtilitiesPlayerData;
+import serverutils.lib.command.CmdBase;
+import serverutils.lib.command.CommandUtils;
+import serverutils.lib.data.Universe;
+
+import java.util.List;
+
+public class CmdHomes extends CmdBase {
+
+    public CmdHomes() {
+        super("homes", Level.ALL);
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length == 1) {
+            return getListOfStringsFromIterableMatchingLastWord(
+                    args,
+                    ServerUtilitiesPlayerData.get(Universe.get().getPlayer(sender)).homes.list());
+        }
+
+        return super.addTabCompletionOptions(sender, args);
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) throws CommandException {
+        EntityPlayerMP player = getCommandSenderAsPlayer(sender);
+        ServerUtilitiesPlayerData data = ServerUtilitiesPlayerData.get(CommandUtils.getForgePlayer(player));
+
+        sender.addChatMessage(ServerUtilities.lang(sender, "serverutilities.lang.homes.homes"));
+        data.homes.list().forEach(home -> sender.addChatMessage(new ChatComponentText(home)));
+
+        data.player.markDirty();
+    }
+}

--- a/src/main/resources/assets/serverutilities/lang/en_US.lang
+++ b/src/main/resources/assets/serverutilities/lang/en_US.lang
@@ -442,6 +442,7 @@ serverutilities.lang.warps.no_dp=You can only go back once!
 serverutilities.lang.warps.no_pos_found=No position to go back to!
 
 # Homes
+serverutilities.lang.homes.homes=---------- Homes ----------
 serverutilities.lang.homes.set=Home '%s' set!
 serverutilities.lang.homes.del=Home '%s' deleted!
 serverutilities.lang.homes.not_set=Unknown Home: '%s'!


### PR DESCRIPTION
Lists all the home points set.

Useful for people with many homes set, as well as using this in combination with `delhome` to cleanup.


If this is of interest I could add the same for warps, as well as commands to delete all homes/warps for instance. 