### PR TITLE
Fix permissions with values above max getting set to default value

### DIFF
--- a/src/main/java/serverutils/lib/config/ConfigInt.java
+++ b/src/main/java/serverutils/lib/config/ConfigInt.java
@@ -138,10 +138,10 @@ public class ConfigInt extends ConfigValue implements IntSupplier {
     public boolean setValueFromString(@Nullable ICommandSender sender, String string, boolean simulate) {
         try {
             int val;
-            if(string.startsWith("#") || string.length() >= 10) {
-               val = Long.decode(string).intValue();
-            }else{
-               val = Integer.parseInt(string);
+            if (string.startsWith("#") || string.length() >= 10) {
+                val = Long.decode(string).intValue();
+            } else {
+                val = Integer.parseInt(string);
             }
 
             if (!simulate) {

--- a/src/main/java/serverutils/lib/config/ConfigInt.java
+++ b/src/main/java/serverutils/lib/config/ConfigInt.java
@@ -137,10 +137,11 @@ public class ConfigInt extends ConfigValue implements IntSupplier {
     @Override
     public boolean setValueFromString(@Nullable ICommandSender sender, String string, boolean simulate) {
         try {
-            int val = string.startsWith("#") ? Long.decode(string).intValue() : Integer.parseInt(string);
-
-            if (val < getMin() || val > getMax()) {
-                return false;
+            int val;
+            if(string.startsWith("#") || string.length() >= 10) {
+               val = Long.decode(string).intValue();
+            }else{
+               val = Integer.parseInt(string);
             }
 
             if (!simulate) {


### PR DESCRIPTION
Beforehand any permission node above the max/min defined values would be disregarded and use the default value instead. The value is already getting clamped by setInt so there's no need for that.

![perm](https://github.com/GTNewHorizons/ServerUtilities/assets/127234178/834aaf17-1202-4dcc-9807-d9802f5ebc6d)
Before this permission node would be set to the default value of 50.
Now it gets correctly clamped to 30000 which is the max for chunk/claim nodes.

Any value above int max would likewise get disregarded before as Integer.parseint can't handle that. Now if the value has a chance to be above int max we decode it as a long and get the int value of that. This will of course lose some data but not in a way that matters in this case.