### PR TITLE
Hide sidebar buttons if disabled on server

### DIFF
--- a/src/main/java/serverutils/client/gui/SidebarButton.java
+++ b/src/main/java/serverutils/client/gui/SidebarButton.java
@@ -90,6 +90,10 @@ public class SidebarButton implements Comparable<SidebarButton> {
             addVisibilityCondition(NEI_NOT_LOADED);
         }
 
+        if (json.has("hide_if_server_disabled") && json.get("hide_if_server_disabled").getAsBoolean()) {
+            addVisibilityCondition(() -> SidedUtils.isButtonEnabledOnServer(id));
+        }
+
         if (json.has("required_server_mods")) {
             LinkedHashSet<String> requiredServerMods = new LinkedHashSet<>();
 

--- a/src/main/java/serverutils/lib/util/SidedUtils.java
+++ b/src/main/java/serverutils/lib/util/SidedUtils.java
@@ -12,11 +12,13 @@ import net.minecraft.command.ICommandSender;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.IChatComponent;
+import net.minecraft.util.ResourceLocation;
 
 public class SidedUtils {
 
     public static Map<String, String> SERVER_MODS = new HashMap<>();
     public static UUID UNIVERSE_UUID_CLIENT = null;
+    public static boolean trashCan = false, teams = false, chunkClaiming = false;
 
     public static IChatComponent lang(@Nullable ICommandSender sender, String mod, String key, Object... args) {
         if (ServerUtils.isVanillaClient(sender)) {
@@ -45,5 +47,14 @@ public class SidedUtils {
         }
 
         return true;
+    }
+
+    public static boolean isButtonEnabledOnServer(ResourceLocation buttonId) {
+        return switch (buttonId.toString()) {
+            case "serverutilities:trash_can" -> trashCan;
+            case "serverutilities:my_team" -> teams;
+            case "serverutilities:claimed_chunks" -> chunkClaiming;
+            default -> true;
+        };
     }
 }

--- a/src/main/java/serverutils/net/MessageSyncData.java
+++ b/src/main/java/serverutils/net/MessageSyncData.java
@@ -32,6 +32,9 @@ public class MessageSyncData extends MessageToClient {
 
     private static final int LOGIN = 1;
     private static final int OP = 2;
+    private static final int TRASH_CAN = 4;
+    private static final int CHUNK_CLAIM = 8;
+    private static final int TEAMS = 16;
 
     private int flags;
     private UUID universeId;
@@ -43,8 +46,14 @@ public class MessageSyncData extends MessageToClient {
 
     public MessageSyncData(boolean login, EntityPlayerMP player, ForgePlayer forgePlayer) {
         boolean op = MinecraftServer.getServer().getConfigurationManager().func_152596_g(player.getGameProfile());
+        boolean trash = ServerUtilitiesConfig.commands.trash_can;
+        boolean claiming = ServerUtilitiesConfig.world.chunk_claiming;
+        boolean teams = ServerUtilitiesConfig.teams.disable_teams;
         flags = Bits.setFlag(0, LOGIN, login);
         flags = Bits.setFlag(flags, OP, op);
+        flags = Bits.setFlag(flags, TRASH_CAN, trash);
+        flags = Bits.setFlag(flags, CHUNK_CLAIM, claiming);
+        flags = Bits.setFlag(flags, TEAMS, !teams);
         universeId = forgePlayer.team.universe.getUUID();
         syncData = new NBTTagCompound();
 
@@ -106,8 +115,11 @@ public class MessageSyncData extends MessageToClient {
             ServerUtilities.LOGGER
                     .info("Synced data from universe " + StringUtils.fromUUID(SidedUtils.UNIVERSE_UUID_CLIENT));
         }
+        ClientUtils.is_op = Bits.getFlag(flags, OP);
 
         SidedUtils.SERVER_MODS.putAll(modList);
-        ClientUtils.is_op = Bits.getFlag(flags, OP);
+        SidedUtils.trashCan = Bits.getFlag(flags, TRASH_CAN);
+        SidedUtils.chunkClaiming = Bits.getFlag(flags, CHUNK_CLAIM);
+        SidedUtils.teams = Bits.getFlag(flags, TEAMS);
     }
 }

--- a/src/main/java/serverutils/ranks/Ranks.java
+++ b/src/main/java/serverutils/ranks/Ranks.java
@@ -101,8 +101,8 @@ public class Ranks {
             pRank.setPermission(ServerUtilitiesPermissions.CLAIMS_MAX_CHUNKS, 100);
             pRank.setPermission(ServerUtilitiesPermissions.CHUNKLOADER_MAX_CHUNKS, 50);
             pRank.setPermission(ServerUtilitiesPermissions.HOMES_MAX, 1);
-            pRank.setPermission(ServerUtilitiesPermissions.HOMES_WARMUP, 5);
-            pRank.setPermission(ServerUtilitiesPermissions.HOMES_COOLDOWN, 5);
+            pRank.setPermission(ServerUtilitiesPermissions.HOMES_WARMUP, "5s");
+            pRank.setPermission(ServerUtilitiesPermissions.HOMES_COOLDOWN, "5s");
             pRank.setPermission(ServerUtilitiesPermissions.HOMES_MAX, 1);
             pRank.setPermission("example.permission", true);
             pRank.setPermission("example.other_permission", false);
@@ -115,8 +115,8 @@ public class Ranks {
             vRank.setPermission(ServerUtilitiesPermissions.CLAIMS_MAX_CHUNKS, 500);
             vRank.setPermission(ServerUtilitiesPermissions.CHUNKLOADER_MAX_CHUNKS, 100);
             vRank.setPermission(ServerUtilitiesPermissions.HOMES_MAX, 25);
-            vRank.setPermission(ServerUtilitiesPermissions.HOMES_WARMUP, 0);
-            vRank.setPermission(ServerUtilitiesPermissions.HOMES_COOLDOWN, 1);
+            vRank.setPermission(ServerUtilitiesPermissions.HOMES_WARMUP, "0s");
+            vRank.setPermission(ServerUtilitiesPermissions.HOMES_COOLDOWN, "1s");
             vRank.setPermission(ServerUtilitiesPermissions.HOMES_CROSS_DIM, true);
             vRank.setPermission("example.other_permission", true);
             vRank.setPermission("example.permission_with_value", 15);
@@ -130,8 +130,8 @@ public class Ranks {
             aRank.setPermission(ServerUtilitiesPermissions.CHUNKLOADER_MAX_CHUNKS, 1000);
             aRank.setPermission(ServerUtilitiesPermissions.CLAIMS_BYPASS_LIMITS, true);
             aRank.setPermission(ServerUtilitiesPermissions.HOMES_MAX, 100);
-            aRank.setPermission(ServerUtilitiesPermissions.HOMES_WARMUP, 0);
-            aRank.setPermission(ServerUtilitiesPermissions.HOMES_COOLDOWN, 0);
+            aRank.setPermission(ServerUtilitiesPermissions.HOMES_WARMUP, "0s");
+            aRank.setPermission(ServerUtilitiesPermissions.HOMES_COOLDOWN, "0s");
             aRank.setPermission(ServerUtilitiesPermissions.HOMES_CROSS_DIM, true);
             aRank.setPermission("example.permission_with_value", 100);
 

--- a/src/main/resources/assets/serverutilities/sidebar_buttons.json
+++ b/src/main/resources/assets/serverutilities/sidebar_buttons.json
@@ -5,7 +5,8 @@
 		"x": 0,
 		"click": "custom:serverutilities:my_team_gui",
 		"required_server_mods": ["serverutilities"],
-		"loading_screen": true
+		"loading_screen": true,
+		"hide_if_server_disabled": true
 	},
 	"settings": {
 		"group": "serverutilities:info",
@@ -36,7 +37,8 @@
 		"x": 0,
 		"click": "serverutilities:claims_gui",
 		"required_server_mods": ["serverutilities"],
-		"loading_screen": true
+		"loading_screen": true,
+		"hide_if_server_disabled": true
 	},
 	"trash_can": {
 		"group": "serverutilities:util",
@@ -44,7 +46,8 @@
 		"x": 150,
 		"click": "command:/trash_can",
 		"required_server_mods": ["serverutilities"],
-		"loading_screen": true
+		"loading_screen": true,
+		"hide_if_server_disabled": true
 	},
 	"heal": {
 		"group": "serverutilities:cheat",


### PR DESCRIPTION
Hides the teams, chunk and trash can buttons if their corresponding config is disabled server side. They don't serve any purpose if disabled and will just cause confusion.

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15551