### PR TITLE
Rename power permission node to priority

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesPermissions.java
+++ b/src/main/java/serverutils/ServerUtilitiesPermissions.java
@@ -77,8 +77,6 @@ public class ServerUtilitiesPermissions {
 
     // Chunkloader //
     public static final String CHUNKLOADER_MAX_CHUNKS = "serverutilities.chunkloader.max_chunks";
-    // public static final String CHUNKLOADER_OFFLINE_TIMER = ServerUtilities.MOD_ID +
-    // ".chunkloader.offline_timer";
     public static final String CHUNKLOADER_LOAD_OFFLINE = "serverutilities.chunkloader.load_offline";
 
     // Chat //
@@ -279,6 +277,7 @@ public class ServerUtilitiesPermissions {
         event.register(Rank.NODE_DEFAULT_PLAYER, new ConfigBoolean(false), new ConfigBoolean(false));
         event.register(Rank.NODE_DEFAULT_OP, new ConfigBoolean(false), new ConfigBoolean(false));
         event.register(Rank.NODE_POWER, new ConfigInt(0, 0, Integer.MAX_VALUE - 1), new ConfigInt(0));
+        event.register(Rank.NODE_PRIORITY, new ConfigInt(0, 0, Integer.MAX_VALUE - 1), new ConfigInt(0));
 
         event.register(CHAT_NAME_FORMAT, new ConfigString("<{name}>"), new ConfigString("<&2{name}&r>"));
         event.register(CHAT_TEXT_COLOR, new ConfigEnum<>(TextComponentParser.TEXT_FORMATTING_COLORS_NAME_MAP));
@@ -298,8 +297,6 @@ public class ServerUtilitiesPermissions {
         event.register(RTP_WARMUP, new ConfigTimer(Ticks.SECOND.x(5), Ticks.MINUTE), new ConfigTimer(Ticks.NO_TICKS));
         event.register(CLAIMS_MAX_CHUNKS, new ConfigInt(100, 0, 30000), new ConfigInt(1000));
         event.register(CHUNKLOADER_MAX_CHUNKS, new ConfigInt(50, 0, 30000), new ConfigInt(64));
-        // event.register(CHUNKLOADER_OFFLINE_TIMER, new ConfigDouble(-1D).setMin(-1D),
-        // new ConfigDouble(-1D));
         event.register(AFK_TIMER, new ConfigTimer(Ticks.NO_TICKS));
     }
 

--- a/src/main/java/serverutils/ranks/PlayerRank.java
+++ b/src/main/java/serverutils/ranks/PlayerRank.java
@@ -36,7 +36,7 @@ public class PlayerRank extends Rank {
     }
 
     @Override
-    public int getPower() {
+    public int getPriority() {
         return Integer.MAX_VALUE;
     }
 

--- a/src/main/java/serverutils/ranks/Rank.java
+++ b/src/main/java/serverutils/ranks/Rank.java
@@ -28,8 +28,11 @@ public class Rank extends FinalIDObject implements Comparable<Rank> {
     public static final String NODE_PARENT = "parent";
     public static final String NODE_DEFAULT_PLAYER = "default_player_rank";
     public static final String NODE_DEFAULT_OP = "default_op_rank";
-    public static final String NODE_POWER = "power";
+    public static final String NODE_PRIORITY = "priority";
     public static final String NODE_COMMAND = "command";
+
+    @Deprecated
+    public static final String NODE_POWER = "power";
 
     public static class Entry implements Comparable<Entry> {
 
@@ -53,7 +56,7 @@ public class Rank extends FinalIDObject implements Comparable<Rank> {
     }
 
     public final Ranks ranks;
-    private int power;
+    private int priority;
     protected IChatComponent displayName;
     protected Set<Rank> parents;
     public final Map<String, Entry> permissions;
@@ -66,21 +69,21 @@ public class Rank extends FinalIDObject implements Comparable<Rank> {
         ranks = r;
         permissions = new LinkedHashMap<>();
         comment = "";
-        power = -1;
+        priority = -1;
     }
 
-    public int getPower() {
-        if (power == -1) {
+    public int getPriority() {
+        if (priority == -1) {
             String s = getLocalPermission(NODE_POWER);
+            String s1 = getLocalPermission(NODE_PRIORITY);
+            int pow = s.isEmpty() ? 0 : Integer.parseInt(s);
+            int pri = s1.isEmpty() ? 0 : Integer.parseInt(s1);
+            int actualPriority = Math.max(pri, pow);
 
-            if (s.isEmpty()) {
-                power = 0;
-            } else {
-                power = MathHelper.clamp_int(Integer.parseInt(s), 0, Integer.MAX_VALUE - 1);
-            }
+            priority = MathHelper.clamp_int(actualPriority, 0, Integer.MAX_VALUE - 1);
         }
 
-        return power;
+        return priority;
     }
 
     public boolean isPlayer() {
@@ -89,7 +92,7 @@ public class Rank extends FinalIDObject implements Comparable<Rank> {
 
     public void clearCache() {
         parents = null;
-        power = -1;
+        priority = -1;
     }
 
     public IChatComponent getDisplayName() {
@@ -148,7 +151,7 @@ public class Rank extends FinalIDObject implements Comparable<Rank> {
     }
 
     public boolean clearParents() {
-        power = -1;
+        priority = -1;
         parents = null;
         return setPermission(NODE_PARENT, "") != null;
     }
@@ -263,7 +266,7 @@ public class Rank extends FinalIDObject implements Comparable<Rank> {
 
     @Override
     public int compareTo(Rank o) {
-        return Integer.compare(o.getPower(), getPower());
+        return Integer.compare(o.getPriority(), getPriority());
     }
 
     public boolean isDefaultPlayerRank() {

--- a/src/main/java/serverutils/ranks/Ranks.java
+++ b/src/main/java/serverutils/ranks/Ranks.java
@@ -97,7 +97,7 @@ public class Ranks {
             Rank pRank = new Rank(this, "player");
             pRank.add();
             pRank.setPermission(Rank.NODE_DEFAULT_PLAYER, true);
-            pRank.setPermission(Rank.NODE_POWER, 1);
+            pRank.setPermission(Rank.NODE_PRIORITY, 1);
             pRank.setPermission(ServerUtilitiesPermissions.CLAIMS_MAX_CHUNKS, 100);
             pRank.setPermission(ServerUtilitiesPermissions.CHUNKLOADER_MAX_CHUNKS, 50);
             pRank.setPermission(ServerUtilitiesPermissions.HOMES_MAX, 1);
@@ -110,7 +110,7 @@ public class Ranks {
 
             Rank vRank = new Rank(this, "vip");
             vRank.add();
-            vRank.setPermission(Rank.NODE_POWER, 20);
+            vRank.setPermission(Rank.NODE_PRIORITY, 20);
             vRank.setPermission(ServerUtilitiesPermissions.CHAT_NAME_FORMAT, "<&bVIP {name}&r>");
             vRank.setPermission(ServerUtilitiesPermissions.CLAIMS_MAX_CHUNKS, 500);
             vRank.setPermission(ServerUtilitiesPermissions.CHUNKLOADER_MAX_CHUNKS, 100);
@@ -124,7 +124,7 @@ public class Ranks {
             Rank aRank = new Rank(this, "admin");
             aRank.add();
             aRank.setPermission(Rank.NODE_DEFAULT_OP, true);
-            aRank.setPermission(Rank.NODE_POWER, 100);
+            aRank.setPermission(Rank.NODE_PRIORITY, 100);
             aRank.setPermission(ServerUtilitiesPermissions.CHAT_NAME_FORMAT, "<&2{name}&r>");
             aRank.setPermission(ServerUtilitiesPermissions.CLAIMS_MAX_CHUNKS, 5000);
             aRank.setPermission(ServerUtilitiesPermissions.CHUNKLOADER_MAX_CHUNKS, 1000);
@@ -189,7 +189,7 @@ public class Ranks {
                 if (!currentRank.isPlayer()) {
                     if (isValidName(currentRank.getId())) {
                         currentRank.add();
-                        currentRank.setPermission(Rank.NODE_POWER, String.valueOf(ranks.size()));
+                        currentRank.setPermission(Rank.NODE_PRIORITY, String.valueOf(ranks.size()));
                     } else {
                         currentRank = null;
                         continue;
@@ -303,7 +303,7 @@ public class Ranks {
                 if (!currentRank.isPlayer()) {
                     if (isValidName(currentRank.getId())) {
                         currentRank.add();
-                        currentRank.setPermission(Rank.NODE_POWER, String.valueOf(ranks.size()));
+                        currentRank.setPermission(Rank.NODE_PRIORITY, String.valueOf(ranks.size()));
                     } else {
                         currentRank = null;
                         continue;
@@ -345,7 +345,7 @@ public class Ranks {
         }
 
         for (Rank rank : playerRanks.values()) {
-            if (rank.setPermission(Rank.NODE_POWER, "") != null) {
+            if (rank.setPermission(Rank.NODE_PRIORITY, "") != null) {
                 save = true;
             }
         }
@@ -458,11 +458,11 @@ public class Ranks {
                 }
             }
 
-            int power = Integer.MAX_VALUE;
+            int priority = Integer.MAX_VALUE;
 
             for (Rank rank : ranks.values()) {
-                if (rank.getPower() <= power) {
-                    power = rank.getPower();
+                if (rank.getPriority() <= priority) {
+                    priority = rank.getPriority();
                     defaultPlayerRank = Optional.of(rank);
                 }
             }
@@ -485,11 +485,11 @@ public class Ranks {
                 }
             }
 
-            int power = 0;
+            int priority = 0;
 
             for (Rank rank : ranks.values()) {
-                if (rank.getPower() >= power) {
-                    power = rank.getPower();
+                if (rank.getPriority() >= priority) {
+                    priority = rank.getPriority();
                     defaultOPRank = Optional.of(rank);
                 }
             }

--- a/src/main/resources/assets/serverutilities/lang/en_US.lang
+++ b/src/main/resources/assets/serverutilities/lang/en_US.lang
@@ -217,6 +217,11 @@ permission.serverutilities.chat.prefix.right.text=Chat Prefix Text
 permission.serverutilities.chat.suffix.left.text=Chat Suffix Text [Left]
 permission.serverutilities.chat.suffix.base.text=Chat Suffix Text [Base]
 permission.serverutilities.chat.suffix.right.text=Chat Suffix Text [Right]
+permission.default_op_rank=Default rank for players with OP or singleplayer with cheat enabled.
+permission.default_player_rank=Default rank for players
+permission.parent=Rank whose permissions will be inherited
+permission.power=Deprecated, see priority.
+permission.priority=Determines which ranks permissions will be prioritized if a player has multiple ranks. Higher = prioritized first.
 
 # Player Settings
 player_config=My Server Settings


### PR DESCRIPTION
People felt that priority provided better clarity which I agree with.

The old power node is still able to be used in order to keep compat with old rank configs. If a rank has both the priority and old power node, whichever one is highest will be used.