### PR TITLE
Add config for allowing all block interactions in claimed chunks

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -84,9 +84,11 @@ public class ServerUtilitiesConfig {
         teams.grief_protection = config
                 .get(TEAM_CAT, "grief_protection", true, "Don't allow other players to break blocks in claimed chunks")
                 .getBoolean();
-        teams.interaction_protection = config
-                .get(TEAM_CAT, "interaction_protection", true, "Don't allow other players to interact with blocks in claimed chunks")
-                .getBoolean();
+        teams.interaction_protection = config.get(
+                TEAM_CAT,
+                "interaction_protection",
+                true,
+                "Don't allow other players to interact with blocks in claimed chunks").getBoolean();
 
         config.setCategoryComment(DEBUG_CAT, "Don't set any values to true, unless you are debugging the mod.");
         debugging.special_commands = config.get(DEBUG_CAT, "special_commands", false, "Enables special debug commands.")

--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -81,6 +81,13 @@ public class ServerUtilitiesConfig {
                 .get(TEAM_CAT, "hide_team_notification", false, "Disable no team notification entirely.")
                 .setLanguageKey("player_config.serverutilities.hide_team_notification").getBoolean();
 
+        teams.grief_protection = config
+                .get(TEAM_CAT, "grief_protection", true, "Don't allow other players to break blocks in claimed chunks")
+                .getBoolean();
+        teams.interaction_protection = config
+                .get(TEAM_CAT, "interaction_protection", true, "Don't allow other players to interact with blocks in claimed chunks")
+                .getBoolean();
+
         config.setCategoryComment(DEBUG_CAT, "Don't set any values to true, unless you are debugging the mod.");
         debugging.special_commands = config.get(DEBUG_CAT, "special_commands", false, "Enables special debug commands.")
                 .getBoolean();
@@ -363,6 +370,8 @@ public class ServerUtilitiesConfig {
         public boolean autocreate_mp;
         public boolean autocreate_sp;
         public boolean hide_team_notification;
+        public boolean grief_protection;
+        public boolean interaction_protection;
     }
 
     public static class Debugging {

--- a/src/main/java/serverutils/ServerUtilitiesPermissions.java
+++ b/src/main/java/serverutils/ServerUtilitiesPermissions.java
@@ -170,6 +170,14 @@ public class ServerUtilitiesPermissions {
                 DefaultPermissionLevel.OP,
                 "Allow to attack animals in claimed chunks");
         PermissionAPI.registerNode(
+                CLAIMS_BLOCK_EDIT_PREFIX,
+                DefaultPermissionLevel.OP,
+                "Permission for blocks that players can break and place within claimed chunks. No block specified = all blocks.");
+        PermissionAPI.registerNode(
+                CLAIMS_BLOCK_INTERACT_PREFIX,
+                DefaultPermissionLevel.OP,
+                "Permission for blocks that players can right-click within claimed chunks. No block specified = all blocks.");
+        PermissionAPI.registerNode(
                 CHUNKLOADER_LOAD_OFFLINE,
                 DefaultPermissionLevel.ALL,
                 "Keep loaded chunks working when player goes offline");
@@ -306,14 +314,6 @@ public class ServerUtilitiesPermissions {
                 Rank.NODE_COMMAND,
                 DefaultPermissionLevel.OP,
                 "Permission for commands, if ServerUtilities command overriding is enabled. If not, this String will be inactive");
-        event.register(
-                CLAIMS_BLOCK_EDIT_PREFIX,
-                DefaultPermissionLevel.OP,
-                "Permission for blocks that players can break and place within claimed chunks");
-        event.register(
-                CLAIMS_BLOCK_INTERACT_PREFIX,
-                DefaultPermissionLevel.OP,
-                "Permission for blocks that players can right-click within claimed chunks");
         event.register(
                 CLAIMS_ITEM_PREFIX,
                 DefaultPermissionLevel.ALL,

--- a/src/main/java/serverutils/ServerUtilitiesPermissions.java
+++ b/src/main/java/serverutils/ServerUtilitiesPermissions.java
@@ -170,14 +170,6 @@ public class ServerUtilitiesPermissions {
                 DefaultPermissionLevel.OP,
                 "Allow to attack animals in claimed chunks");
         PermissionAPI.registerNode(
-                CLAIMS_BLOCK_EDIT_PREFIX,
-                DefaultPermissionLevel.OP,
-                "Permission for blocks that players can break and place within claimed chunks. No block specified = all blocks.");
-        PermissionAPI.registerNode(
-                CLAIMS_BLOCK_INTERACT_PREFIX,
-                DefaultPermissionLevel.OP,
-                "Permission for blocks that players can right-click within claimed chunks. No block specified = all blocks.");
-        PermissionAPI.registerNode(
                 CHUNKLOADER_LOAD_OFFLINE,
                 DefaultPermissionLevel.ALL,
                 "Keep loaded chunks working when player goes offline");
@@ -314,6 +306,14 @@ public class ServerUtilitiesPermissions {
                 Rank.NODE_COMMAND,
                 DefaultPermissionLevel.OP,
                 "Permission for commands, if ServerUtilities command overriding is enabled. If not, this String will be inactive");
+        event.register(
+                CLAIMS_BLOCK_EDIT_PREFIX,
+                DefaultPermissionLevel.OP,
+                "Permission for blocks that players can break and place within claimed chunks");
+        event.register(
+                CLAIMS_BLOCK_INTERACT_PREFIX,
+                DefaultPermissionLevel.OP,
+                "Permission for blocks that players can right-click within claimed chunks");
         event.register(
                 CLAIMS_ITEM_PREFIX,
                 DefaultPermissionLevel.ALL,

--- a/src/main/java/serverutils/data/ClaimedChunks.java
+++ b/src/main/java/serverutils/data/ClaimedChunks.java
@@ -238,7 +238,8 @@ public class ClaimedChunks {
 
         ClaimedChunk chunk = instance.getChunk(new ChunkDimPos(x, y, z, player.dimension));
 
-        return chunk != null && !PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.CLAIMS_BLOCK_EDIT_PREFIX)
+        return chunk != null
+                && !PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.CLAIMS_BLOCK_EDIT_PREFIX)
                 && !ServerUtilitiesPermissions.hasBlockEditingPermission(player, block)
                 && !chunk.getTeam()
                         .hasStatus(instance.universe.getPlayer(player), chunk.getData().getEditBlocksStatus());
@@ -256,7 +257,8 @@ public class ClaimedChunks {
         Block block = player.worldObj.getBlock(x, y, z);
 
         ClaimedChunk chunk = instance.getChunk(new ChunkDimPos(x, y, z, player.dimension));
-        return chunk != null && !PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.CLAIMS_BLOCK_INTERACT_PREFIX)
+        return chunk != null
+                && !PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.CLAIMS_BLOCK_INTERACT_PREFIX)
                 && !ServerUtilitiesPermissions.hasBlockInteractionPermission(player, block)
                 && !chunk.getTeam()
                         .hasStatus(instance.universe.getPlayer(player), chunk.getData().getInteractWithBlocksStatus());

--- a/src/main/java/serverutils/data/ClaimedChunks.java
+++ b/src/main/java/serverutils/data/ClaimedChunks.java
@@ -238,7 +238,8 @@ public class ClaimedChunks {
 
         ClaimedChunk chunk = instance.getChunk(new ChunkDimPos(x, y, z, player.dimension));
 
-        return chunk != null && !ServerUtilitiesPermissions.hasBlockEditingPermission(player, block)
+        return chunk != null && !PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.CLAIMS_BLOCK_EDIT_PREFIX)
+                && !ServerUtilitiesPermissions.hasBlockEditingPermission(player, block)
                 && !chunk.getTeam()
                         .hasStatus(instance.universe.getPlayer(player), chunk.getData().getEditBlocksStatus());
     }
@@ -255,7 +256,8 @@ public class ClaimedChunks {
         Block block = player.worldObj.getBlock(x, y, z);
 
         ClaimedChunk chunk = instance.getChunk(new ChunkDimPos(x, y, z, player.dimension));
-        return chunk != null && !ServerUtilitiesPermissions.hasBlockInteractionPermission(player, block)
+        return chunk != null && !PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.CLAIMS_BLOCK_INTERACT_PREFIX)
+                && !ServerUtilitiesPermissions.hasBlockInteractionPermission(player, block)
                 && !chunk.getTeam()
                         .hasStatus(instance.universe.getPlayer(player), chunk.getData().getInteractWithBlocksStatus());
     }

--- a/src/main/java/serverutils/data/ClaimedChunks.java
+++ b/src/main/java/serverutils/data/ClaimedChunks.java
@@ -226,7 +226,9 @@ public class ClaimedChunks {
     }
 
     public static boolean blockBlockEditing(EntityPlayer player, int x, int y, int z, int meta) {
-        if (!isActive() || player.worldObj == null || !(player instanceof EntityPlayerMP) || !ServerUtilitiesConfig.teams.grief_protection) {
+        if (!isActive() || player.worldObj == null
+                || !(player instanceof EntityPlayerMP)
+                || !ServerUtilitiesConfig.teams.grief_protection) {
             return false;
         }
 
@@ -244,7 +246,9 @@ public class ClaimedChunks {
     }
 
     public static boolean blockBlockInteractions(EntityPlayer player, int x, int y, int z, int meta) {
-        if (!isActive() || player.worldObj == null || !(player instanceof EntityPlayerMP) || !ServerUtilitiesConfig.teams.interaction_protection) {
+        if (!isActive() || player.worldObj == null
+                || !(player instanceof EntityPlayerMP)
+                || !ServerUtilitiesConfig.teams.interaction_protection) {
             return false;
         }
 

--- a/src/main/java/serverutils/data/ClaimedChunks.java
+++ b/src/main/java/serverutils/data/ClaimedChunks.java
@@ -226,7 +226,7 @@ public class ClaimedChunks {
     }
 
     public static boolean blockBlockEditing(EntityPlayer player, int x, int y, int z, int meta) {
-        if (!isActive() || player.worldObj == null || !(player instanceof EntityPlayerMP)) {
+        if (!isActive() || player.worldObj == null || !(player instanceof EntityPlayerMP) || !ServerUtilitiesConfig.teams.grief_protection) {
             return false;
         }
 
@@ -238,15 +238,13 @@ public class ClaimedChunks {
 
         ClaimedChunk chunk = instance.getChunk(new ChunkDimPos(x, y, z, player.dimension));
 
-        return chunk != null
-                && !PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.CLAIMS_BLOCK_EDIT_PREFIX)
-                && !ServerUtilitiesPermissions.hasBlockEditingPermission(player, block)
+        return chunk != null && !ServerUtilitiesPermissions.hasBlockEditingPermission(player, block)
                 && !chunk.getTeam()
                         .hasStatus(instance.universe.getPlayer(player), chunk.getData().getEditBlocksStatus());
     }
 
     public static boolean blockBlockInteractions(EntityPlayer player, int x, int y, int z, int meta) {
-        if (!isActive() || player.worldObj == null || !(player instanceof EntityPlayerMP)) {
+        if (!isActive() || player.worldObj == null || !(player instanceof EntityPlayerMP) || !ServerUtilitiesConfig.teams.interaction_protection) {
             return false;
         }
 
@@ -257,9 +255,7 @@ public class ClaimedChunks {
         Block block = player.worldObj.getBlock(x, y, z);
 
         ClaimedChunk chunk = instance.getChunk(new ChunkDimPos(x, y, z, player.dimension));
-        return chunk != null
-                && !PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.CLAIMS_BLOCK_INTERACT_PREFIX)
-                && !ServerUtilitiesPermissions.hasBlockInteractionPermission(player, block)
+        return chunk != null && !ServerUtilitiesPermissions.hasBlockInteractionPermission(player, block)
                 && !chunk.getTeam()
                         .hasStatus(instance.universe.getPlayer(player), chunk.getData().getInteractWithBlocksStatus());
     }


### PR DESCRIPTION
This allows for servers which want to use claims for chunkloading but do not want chunk protection. This PR is untested because I don't have any other accounts to test with, so please test it if you think it might break something :)