### PR TITLE
Fix backups not getting deleted under certain circumstances

### DIFF
--- a/src/main/java/serverutils/backups/Backups.java
+++ b/src/main/java/serverutils/backups/Backups.java
@@ -82,12 +82,9 @@ public class Backups {
             ServerUtilities.LOGGER.info("Deleting " + toDelete + " old backups");
 
             for (int i = 0; i < toDelete; i++) {
-                File f = new File(backupsFolder, backups[1]);
-                // Don't automatically delete backups with custom name
-                if (f.getName().indexOf("-") == 4) {
-                    ServerUtilities.LOGGER.info("Deleted old backup: " + f.getPath());
-                    FileUtils.delete(f);
-                }
+                File f = new File(backupsFolder, backups[i]);
+                ServerUtilities.LOGGER.info("Deleted old backup: " + f.getPath());
+                FileUtils.delete(f);
             }
         }
     }


### PR DESCRIPTION
Somehow an `i` got replaced by a `1` in the for loop.... Don't git blame that 💀

This in combination with backups that have custom names not getting auto deleted led to some interesting situations.

