### PR TITLE
Fix various teleportation problems

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 
 dependencies {
 
-    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.5.23-GTNH:dev")
+    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.5.24-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:VisualProspecting:1.2.10:dev")
     compileOnly("com.github.GTNewHorizons:EnderIO:2.7.1:dev")
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.15'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.19'
 }
 
 

--- a/src/main/java/serverutils/data/ServerUtilitiesPlayerData.java
+++ b/src/main/java/serverutils/data/ServerUtilitiesPlayerData.java
@@ -10,6 +10,7 @@ import javax.annotation.Nullable;
 
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.event.HoverEvent;
 import net.minecraft.nbt.NBTTagCompound;
@@ -116,15 +117,16 @@ public class ServerUtilitiesPlayerData extends PlayerData {
                         StringUtils.color(ServerUtilities.lang(player, "stand_still_failed"), EnumChatFormatting.RED));
             } else if (secondsLeft <= 1) {
                 TeleporterDimPos teleporter = pos.apply(player);
-
                 if (teleporter != null) {
+                    Entity mount = player.ridingEntity;
+                    player.mountEntity(null);
+                    if (mount != null) {
+                        teleporter.teleport(mount);
+                    }
+
                     ServerUtilitiesPlayerData data = get(universe.getPlayer(player));
                     data.setLastTeleport(teleportType, new BlockDimPos(player));
                     teleporter.teleport(player);
-
-                    if (player.ridingEntity != null) {
-                        teleporter.teleport(player.ridingEntity);
-                    }
 
                     data.lastTeleport[timer.ordinal()] = System.currentTimeMillis();
 

--- a/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
@@ -617,6 +617,7 @@ public class ServerUtilitiesClientEventHandler {
             FontRenderer font = mc.fontRenderer;
 
             GlStateManager.enableBlend();
+            GlStateManager.enableDepth();
             GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
             GlStateManager.color(1F, 1F, 1F, 1F);
 
@@ -658,7 +659,6 @@ public class ServerUtilitiesClientEventHandler {
                 }
 
                 GlStateManager.pushMatrix();
-                GlStateManager.enableDepth();
                 GlStateManager.translate(0, 0, 500);
                 GlStateManager.enableBlend();
                 GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
@@ -668,11 +668,11 @@ public class ServerUtilitiesClientEventHandler {
                     font.drawString(list.get(i), mx1, my1 + i * 10, 0xFFFFFFFF);
                 }
                 GlStateManager.color(1F, 1F, 1F, 1F);
-                GlStateManager.disableDepth();
                 GlStateManager.popMatrix();
             }
 
             GlStateManager.color(1F, 1F, 1F, 1F);
+            GlStateManager.disableDepth();
             GlStateManager.popMatrix();
             zLevel = 0F;
 

--- a/src/main/java/serverutils/lib/math/TeleporterDimPos.java
+++ b/src/main/java/serverutils/lib/math/TeleporterDimPos.java
@@ -4,6 +4,7 @@ import javax.annotation.Nullable;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.play.server.S1FPacketSetExperience;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
@@ -78,11 +79,21 @@ public class TeleporterDimPos {
             if (entity instanceof EntityPlayerMP playerMP) {
                 server.getConfigurationManager()
                         .transferPlayerToDimension(playerMP, dim, new EmptyTeleporter(newDim, this));
+                playerMP.playerNetServerHandler.sendPacket(
+                        new S1FPacketSetExperience(
+                                playerMP.experience,
+                                playerMP.experienceTotal,
+                                playerMP.experienceLevel));
+                playerMP.sendPlayerAbilities();
+
+                if (currentDim.provider.dimensionId == 1 && playerMP.isEntityAlive()) {
+                    newDim.spawnEntityInWorld(playerMP);
+                    newDim.updateEntityWithOptionalForce(playerMP, false);
+                }
             } else {
                 server.getConfigurationManager()
                         .transferEntityToWorld(entity, dim, currentDim, newDim, new EmptyTeleporter(newDim, this));
             }
-            return entity;
         }
 
         placeEntity(entity.worldObj, entity, entity.rotationYaw);

--- a/src/main/java/serverutils/lib/util/misc/EmptyTeleporter.java
+++ b/src/main/java/serverutils/lib/util/misc/EmptyTeleporter.java
@@ -19,22 +19,16 @@ public class EmptyTeleporter extends Teleporter {
     public void removeStalePortalLocations(long p_85189_1_) {}
 
     @Override
-    public void placeInPortal(Entity p_77185_1_, double p_77185_2_, double p_77185_4_, double p_77185_6_,
-            float p_77185_8_) {
-        p_77185_1_.motionX = p_77185_1_.motionY = p_77185_1_.motionZ = 0.0D;
-        p_77185_1_.fallDistance = 0F;
-        p_77185_1_.setLocationAndAngles(
-                destination.posX,
-                destination.posY,
-                destination.posZ,
-                p_77185_1_.rotationYaw,
-                0.0F);
+    public void placeInPortal(Entity entity, double posX, double posY, double posZ, float yaw) {
+        placeInExistingPortal(entity, posX, posY, posZ, yaw);
     }
 
     @Override
-    public boolean placeInExistingPortal(Entity p_77184_1_, double p_77184_2_, double p_77184_4_, double p_77184_6_,
-            float p_77184_8_) {
-        return false;
+    public boolean placeInExistingPortal(Entity entity, double posX, double posY, double posZ, float yaw) {
+        entity.motionX = entity.motionY = entity.motionZ = 0.0D;
+        entity.fallDistance = 0F;
+        entity.setLocationAndAngles(destination.posX, destination.posY, destination.posZ, entity.rotationYaw, 0.0F);
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Closes: https://github.com/GTNewHorizons/ServerUtilities/issues/49

1. Fixes the world not loading when teleporting from the end. (Stolen from old FTBLib [here](https://github.com/GTNewHorizons/FTB-Library/blob/a7c09113c95a1d4745b9843ea2bdf7d942d9bcbd/src/main/java/ftb/lib/LMDimUtils.java#L47-L51))
2. Send player abilities when teleporting inter dim so players don't lose their ability to fly if enabled and also send XP packet so it won't show 0 xp on client side after tping.
3. If the player is riding an entity they are dismounted before both are teleported to avoid the same problem as tping from the end causes.

Unrelated to the ticket but I also moved the depth test call for the sidebar buttons to cover both buttons and text. This is done to ensure that the buttons are always drawn on top of the potion labels.