### PR TITLE
Disable clientside config edits if their function is disabled on server

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -39,7 +39,7 @@ public class ServerUtilitiesConfig {
     public static final String DEBUGGING = "debugging";
     public static final String BACKUPS = "backups";
 
-    public static final String[] TRISTATE_VALUES = { "SCREEN", "CHAT", "DISABLED" };
+    public static final String[] TRISTATE_VALUES = { "TRUE", "FALSE", "DEFAULT" };
 
     public static void init(FMLPreInitializationEvent event) {
         config = new Configuration(
@@ -289,15 +289,13 @@ public class ServerUtilitiesConfig {
                 Allowed values:
                 DEFAULT = Players can choose their own PVP status.
                 TRUE = PVP on for everyone.
-                FALSE = PVP disabled for everyone.
-                """).setValidValues(TRISTATE_VALUES).getString());
+                FALSE = PVP disabled for everyone.""").setValidValues(TRISTATE_VALUES).getString());
         world.enable_explosions = EnumTristate
                 .string2tristate(config.get(WORLD, "enable_explosions", EnumTristate.DEFAULT.getName(), """
                         Allowed values:
                         DEFAULT = Teams can decide their explosion setting
                         TRUE = Explosions on for everyone.
-                        FALSE = Explosions disabled for everyone.
-                        """).setValidValues(TRISTATE_VALUES).getString());
+                        FALSE = Explosions disabled for everyone.""").setValidValues(TRISTATE_VALUES).getString());
         world.spawn_radius = config.get(
                 WORLD,
                 "spawn_radius",

--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -39,6 +39,8 @@ public class ServerUtilitiesConfig {
     public static final String DEBUGGING = "debugging";
     public static final String BACKUPS = "backups";
 
+    public static final String[] TRISTATE_VALUES = { "SCREEN", "CHAT", "DISABLED" };
+
     public static void init(FMLPreInitializationEvent event) {
         config = new Configuration(
                 new File(event.getModConfigurationDirectory() + "/../serverutilities/serverutilities.cfg"));
@@ -283,18 +285,19 @@ public class ServerUtilitiesConfig {
                 "blocked_claiming_dimensions",
                 new int[] {},
                 "Dimensions where chunk claiming isn't allowed.").getIntList();
-        world.enable_pvp = EnumTristate.string2tristate(
-                config.get(
-                        WORLD,
-                        "enable_pvp",
-                        EnumTristate.TRUE.getName(),
-                        "If set to DEFAULT, then players can decide their PVP status.").getString());
-        world.enable_explosions = EnumTristate.string2tristate(
-                config.get(
-                        WORLD,
-                        "enable_explosions",
-                        EnumTristate.DEFAULT.getName(),
-                        "If set to DEFAULT, then teams can decide their Explosion setting.").getString());
+        world.enable_pvp = EnumTristate.string2tristate(config.get(WORLD, "enable_pvp", EnumTristate.TRUE.getName(), """
+                Allowed values:
+                DEFAULT = Players can choose their own PVP status.
+                TRUE = PVP on for everyone.
+                FALSE = PVP disabled for everyone.
+                """).setValidValues(TRISTATE_VALUES).getString());
+        world.enable_explosions = EnumTristate
+                .string2tristate(config.get(WORLD, "enable_explosions", EnumTristate.DEFAULT.getName(), """
+                        Allowed values:
+                        DEFAULT = Teams can decide their explosion setting
+                        TRUE = Explosions on for everyone.
+                        FALSE = Explosions disabled for everyone.
+                        """).setValidValues(TRISTATE_VALUES).getString());
         world.spawn_radius = config.get(
                 WORLD,
                 "spawn_radius",

--- a/src/main/java/serverutils/data/ClaimedChunks.java
+++ b/src/main/java/serverutils/data/ClaimedChunks.java
@@ -267,7 +267,8 @@ public class ClaimedChunks {
     public static boolean blockItemUse(EntityPlayer player, int x, int y, int z) {
         if (!isActive() || player.worldObj == null
                 || !(player instanceof EntityPlayerMP)
-                || player.getHeldItem() == null) {
+                || player.getHeldItem() == null
+                || !ServerUtilitiesConfig.teams.grief_protection) {
             return false;
         }
 

--- a/src/main/java/serverutils/data/ServerUtilitiesPlayerData.java
+++ b/src/main/java/serverutils/data/ServerUtilitiesPlayerData.java
@@ -217,15 +217,13 @@ public class ServerUtilitiesPlayerData extends PlayerData {
 
         config.addBool("render_badge", () -> renderBadge, v -> renderBadge = v, true);
         config.addBool("disable_global_badge", () -> disableGlobalBadge, v -> disableGlobalBadge = v, false);
-        config.addBool("enable_pvp", () -> enablePVP, v -> enablePVP = v, true);
-
-        if (ServerUtilitiesConfig.commands.nick && player.hasPermission(ServerUtilitiesPermissions.CHAT_NICKNAME_SET)) {
-            config.addString("nickname", () -> nickname, v -> nickname = v, "");
-        }
-
-        if (ServerUtilitiesConfig.afk.isEnabled(player.team.universe.server)) {
-            config.addEnum("afk", () -> afkMesageLocation, v -> afkMesageLocation = v, EnumMessageLocation.NAME_MAP);
-        }
+        config.addBool("enable_pvp", () -> enablePVP, v -> enablePVP = v, true)
+                .setCanEdit(ServerUtilitiesConfig.world.enable_pvp.isDefault());
+        config.addString("nickname", () -> nickname, v -> nickname = v, "").setCanEdit(
+                ServerUtilitiesConfig.commands.nick
+                        && player.hasPermission(ServerUtilitiesPermissions.CHAT_NICKNAME_SET));
+        config.addEnum("afk", () -> afkMesageLocation, v -> afkMesageLocation = v, EnumMessageLocation.NAME_MAP)
+                .setExcluded(!ServerUtilitiesConfig.afk.isEnabled(player.team.universe.server));
     }
 
     public boolean renderBadge() {

--- a/src/main/java/serverutils/data/ServerUtilitiesTeamData.java
+++ b/src/main/java/serverutils/data/ServerUtilitiesTeamData.java
@@ -14,6 +14,7 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import serverutils.ServerUtilities;
+import serverutils.ServerUtilitiesConfig;
 import serverutils.ServerUtilitiesPermissions;
 import serverutils.events.team.ForgeTeamConfigEvent;
 import serverutils.events.team.ForgeTeamDeletedEvent;
@@ -191,15 +192,18 @@ public class ServerUtilitiesTeamData extends TeamData {
         ConfigGroup group = main.getGroup(ServerUtilities.MOD_ID);
         group.setDisplayName(new ChatComponentText(ServerUtilities.MOD_NAME));
 
-        group.addBool("explosions", () -> explosions, v -> explosions = v, false);
-        group.addEnum("blocks_edit", () -> editBlocks, v -> editBlocks = v, EnumTeamStatus.NAME_MAP_PERMS);
+        group.addBool("explosions", () -> explosions, v -> explosions = v, false)
+                .setCanEdit(ServerUtilitiesConfig.world.enable_explosions.isDefault());
+        group.addEnum("blocks_edit", () -> editBlocks, v -> editBlocks = v, EnumTeamStatus.NAME_MAP_PERMS)
+                .setCanEdit(ServerUtilitiesConfig.teams.grief_protection);
         group.addEnum(
                 "blocks_interact",
                 () -> interactWithBlocks,
                 v -> interactWithBlocks = v,
-                EnumTeamStatus.NAME_MAP_PERMS);
+                EnumTeamStatus.NAME_MAP_PERMS).setCanEdit(ServerUtilitiesConfig.teams.interaction_protection);;
         group.addEnum("attack_entities", () -> attackEntities, v -> attackEntities = v, EnumTeamStatus.NAME_MAP_PERMS);
-        group.addEnum("use_items", () -> useItems, v -> useItems = v, EnumTeamStatus.NAME_MAP_PERMS);
+        group.addEnum("use_items", () -> useItems, v -> useItems = v, EnumTeamStatus.NAME_MAP_PERMS)
+                .setCanEdit(ServerUtilitiesConfig.teams.grief_protection);
     }
 
     public EnumTeamStatus getEditBlocksStatus() {

--- a/src/main/java/serverutils/lib/config/ConfigGroup.java
+++ b/src/main/java/serverutils/lib/config/ConfigGroup.java
@@ -246,6 +246,10 @@ public class ConfigGroup extends FinalIDObject {
     public IChatComponent getInfoOf(ConfigValueInstance inst) {
         IChatComponent name = inst.getDisplayName();
 
+        if (!inst.getCanEdit()) {
+            return new ChatComponentTranslation("serverutilties.config.disabled");
+        }
+
         if (name instanceof ChatComponentTranslation component) {
             return new ChatComponentTranslation(component.getKey() + ".tooltip");
         }

--- a/src/main/java/serverutils/lib/config/EnumTristate.java
+++ b/src/main/java/serverutils/lib/config/EnumTristate.java
@@ -25,7 +25,7 @@ public enum EnumTristate implements IStringSerializable {
     }
 
     public static EnumTristate string2tristate(String tristate) {
-        return switch (tristate) {
+        return switch (tristate.toLowerCase()) {
             case "true" -> TRUE;
             case "false" -> FALSE;
             default -> DEFAULT;

--- a/src/main/java/serverutils/lib/gui/misc/GuiEditConfig.java
+++ b/src/main/java/serverutils/lib/gui/misc/GuiEditConfig.java
@@ -215,11 +215,16 @@ public class GuiEditConfig extends GuiBase {
             if (getMouseY() > 18) {
                 list.add(EnumChatFormatting.UNDERLINE + keyText);
                 IChatComponent infoText = inst.getInfo();
+                EnumChatFormatting color = EnumChatFormatting.GRAY;
+
+                if (!inst.getCanEdit()) {
+                    color = EnumChatFormatting.RED;
+                }
 
                 if (!(infoText instanceof ChatComponentTranslation component)
                         || !LanguageRegistry.instance().getStringLocalization(component.getKey()).isEmpty()) {
                     for (String s : infoText.getFormattedText().split("\\\n")) {
-                        list.add(EnumChatFormatting.GRAY.toString() + EnumChatFormatting.ITALIC + s);
+                        list.add(color.toString() + EnumChatFormatting.ITALIC + s);
                     }
                 }
 
@@ -282,6 +287,8 @@ public class GuiEditConfig extends GuiBase {
             ButtonConfigGroup group = null;
 
             for (ConfigValueInstance instance : list) {
+                if (instance.getExcluded()) continue;
+
                 if (group == null || !group.group.equals(instance.getGroup())) {
                     group = new ButtonConfigGroup(configPanel, instance.getGroup());
                     configEntryButtons.add(group);

--- a/src/main/java/serverutils/lib/gui/misc/GuiEditConfig.java
+++ b/src/main/java/serverutils/lib/gui/misc/GuiEditConfig.java
@@ -5,12 +5,11 @@ import java.util.Comparator;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
+import net.minecraft.util.StatCollector;
 
-import cpw.mods.fml.common.registry.LanguageRegistry;
 import serverutils.lib.client.GlStateManager;
 import serverutils.lib.config.ConfigGroup;
 import serverutils.lib.config.ConfigValueInstance;
@@ -97,11 +96,11 @@ public class GuiEditConfig extends GuiBase {
 
                 title = builder.toString();
             } else {
-                title = I18n.format("stat.generalButton");
+                title = StatCollector.translateToLocal("stat.generalButton");
             }
 
             String infoKey = group.getPath() + ".info";
-            info = !LanguageRegistry.instance().getStringLocalization(infoKey).isEmpty() ? I18n.format(infoKey) : "";
+            info = StatCollector.canTranslate(infoKey) ? StatCollector.translateToLocal(infoKey) : "";
             setCollapsed(collapsed);
         }
 
@@ -222,7 +221,7 @@ public class GuiEditConfig extends GuiBase {
                 }
 
                 if (!(infoText instanceof ChatComponentTranslation component)
-                        || !LanguageRegistry.instance().getStringLocalization(component.getKey()).isEmpty()) {
+                        || StatCollector.canTranslate(component.getKey())) {
                     for (String s : infoText.getFormattedText().split("\\\n")) {
                         list.add(color.toString() + EnumChatFormatting.ITALIC + s);
                     }
@@ -305,30 +304,42 @@ public class GuiEditConfig extends GuiBase {
 
         scroll = new PanelScrollBar(this, configPanel);
 
-        buttonAccept = new SimpleButton(this, I18n.format("gui.close"), GuiIcons.ACCEPT, (widget, button) -> {
-            shouldClose = 1;
-            widget.getGui().closeGui();
-        });
+        buttonAccept = new SimpleButton(
+                this,
+                StatCollector.translateToLocal("gui.close"),
+                GuiIcons.ACCEPT,
+                (widget, button) -> {
+                    shouldClose = 1;
+                    widget.getGui().closeGui();
+                });
 
-        buttonCancel = new SimpleButton(this, I18n.format("gui.cancel"), GuiIcons.CANCEL, (widget, button) -> {
-            shouldClose = 2;
-            widget.getGui().closeGui();
-        });
+        buttonCancel = new SimpleButton(
+                this,
+                StatCollector.translateToLocal("gui.cancel"),
+                GuiIcons.CANCEL,
+                (widget, button) -> {
+                    shouldClose = 2;
+                    widget.getGui().closeGui();
+                });
 
-        buttonExpandAll = new SimpleButton(this, I18n.format("gui.expand_all"), GuiIcons.ADD, (widget, button) -> {
-            for (Widget w : configEntryButtons) {
-                if (w instanceof ButtonConfigGroup configGroup) {
-                    configGroup.setCollapsed(false);
-                }
-            }
+        buttonExpandAll = new SimpleButton(
+                this,
+                StatCollector.translateToLocal("gui.expand_all"),
+                GuiIcons.ADD,
+                (widget, button) -> {
+                    for (Widget w : configEntryButtons) {
+                        if (w instanceof ButtonConfigGroup configGroup) {
+                            configGroup.setCollapsed(false);
+                        }
+                    }
 
-            scroll.setValue(0);
-            widget.getGui().refreshWidgets();
-        });
+                    scroll.setValue(0);
+                    widget.getGui().refreshWidgets();
+                });
 
         buttonCollapseAll = new SimpleButton(
                 this,
-                I18n.format("gui.collapse_all"),
+                StatCollector.translateToLocal("gui.collapse_all"),
                 GuiIcons.REMOVE,
                 (widget, button) -> {
                     for (Widget w : configEntryButtons) {

--- a/src/main/resources/assets/serverutilities/lang/en_US.lang
+++ b/src/main/resources/assets/serverutilities/lang/en_US.lang
@@ -15,7 +15,7 @@ serverutilities.lang.god_on=God mode turned on for %s
 serverutilities.lang.god_off=God mode turned off for %s
 serverutilities.lang.heal=%s has been healed
 serverutilities.lang.permissions_dumped=%s permissions successfully dumped to file at: %s.
-
+serverutilties.config.disabled=Disabled by server.
 serverutilities.vp.button=Show Server Utilities Claims Overlay
 
 serverutilities.stat.dph=Deaths Per Hour


### PR DESCRIPTION
This will only affect settings that are stored on the server but can be edited by the client, such as team settings and "My Server Settings".

I think it's best to display that they're disabled rather than hide them entirely to avoid the confusion of why X feature is missing.


![su_disabled](https://github.com/GTNewHorizons/ServerUtilities/assets/127234178/54ce58e0-d7fe-40c5-8f93-94bbd06e5be6)


This addresses the confusion in https://github.com/GTNewHorizons/ServerUtilities/issues/50