### PR TITLE
Fix some items uses being blocked if 0, 0 is claimed.

### DIFF
--- a/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
@@ -25,7 +25,6 @@ import net.minecraftforge.event.world.BlockEvent;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
-import serverutils.ServerUtilities;
 import serverutils.ServerUtilitiesConfig;
 import serverutils.ServerUtilitiesNotifications;
 import serverutils.ServerUtilitiesPermissions;
@@ -317,7 +316,8 @@ public class ServerUtilitiesPlayerEventHandler {
         if (!(event.entityPlayer instanceof EntityPlayerMP playerMP)) return;
         Entity target = event.target;
         if (ServerUtilitiesConfig.world.logging.entity_attacked && ServerUtilitiesConfig.world.logging.log(playerMP)) {
-            boolean print = !ServerUtilitiesConfig.world.logging.exclude_mob_entity || !(target instanceof EntityCreature);
+            boolean print = !ServerUtilitiesConfig.world.logging.exclude_mob_entity
+                    || !(target instanceof EntityCreature);
             if (print) {
                 ServerUtilitiesUniverseData.worldLog(
                         String.format(

--- a/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
@@ -77,16 +77,6 @@ public class ServerUtilitiesPlayerEventHandler {
         }
 
         Backups.hadPlayer = true;
-
-        // if (ServerUtilitiesConfig.chat.replace_tab_names) {
-        // new MessageUpdateTabName(player).sendToAll();
-        //
-        // for (EntityPlayerMP player1 : player.mcServer.getConfigurationManager().playerEntityList) {
-        // if (player1 != player) {
-        // new MessageUpdateTabName(player1).sendTo(player);
-        // }
-        // }
-        // }
     }
 
     @SubscribeEvent

--- a/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
@@ -25,6 +25,7 @@ import net.minecraftforge.event.world.BlockEvent;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
+import serverutils.ServerUtilities;
 import serverutils.ServerUtilitiesConfig;
 import serverutils.ServerUtilitiesNotifications;
 import serverutils.ServerUtilitiesPermissions;
@@ -316,8 +317,7 @@ public class ServerUtilitiesPlayerEventHandler {
         if (!(event.entityPlayer instanceof EntityPlayerMP playerMP)) return;
         Entity target = event.target;
         if (ServerUtilitiesConfig.world.logging.entity_attacked && ServerUtilitiesConfig.world.logging.log(playerMP)) {
-            boolean print = ServerUtilitiesConfig.world.logging.exclude_mob_entity
-                    || !(event.target instanceof EntityCreature);
+            boolean print = !ServerUtilitiesConfig.world.logging.exclude_mob_entity || !(target instanceof EntityCreature);
             if (print) {
                 ServerUtilitiesUniverseData.worldLog(
                         String.format(

--- a/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
@@ -314,26 +314,16 @@ public class ServerUtilitiesPlayerEventHandler {
     @SubscribeEvent
     public void onEntityAttackedLog(AttackEntityEvent event) {
         if (!(event.entityPlayer instanceof EntityPlayerMP playerMP)) return;
-
         Entity target = event.target;
         if (ServerUtilitiesConfig.world.logging.entity_attacked && ServerUtilitiesConfig.world.logging.log(playerMP)) {
-            if (target instanceof EntityPlayerMP targetPlayer) {
+            boolean print = ServerUtilitiesConfig.world.logging.exclude_mob_entity
+                    || !(event.target instanceof EntityCreature);
+            if (print) {
                 ServerUtilitiesUniverseData.worldLog(
                         String.format(
                                 "%s attacked %s with %s at %s in %s",
                                 playerMP.getCommandSenderName(),
-                                targetPlayer.getDisplayName(),
-                                getHeldItemName(playerMP),
-                                getPos((int) playerMP.posX, (int) playerMP.posY, (int) playerMP.posZ),
-                                getDim(playerMP)));
-            }
-            if (!ServerUtilitiesConfig.world.logging.exclude_mob_entity
-                    && target instanceof EntityCreature targetCreature) {
-                ServerUtilitiesUniverseData.worldLog(
-                        String.format(
-                                "%s attacked %s with %s at %s in %s",
-                                playerMP.getDisplayName(),
-                                targetCreature.getCommandSenderName(),
+                                target.getCommandSenderName(),
                                 getHeldItemName(playerMP),
                                 getPos((int) playerMP.posX, (int) playerMP.posY, (int) playerMP.posZ),
                                 getDim(playerMP)));

--- a/src/main/java/serverutils/lib/math/MathUtils.java
+++ b/src/main/java/serverutils/lib/math/MathUtils.java
@@ -205,8 +205,7 @@ public class MathUtils {
     public static MovingObjectPosition rayTrace(EntityPlayer player, boolean useLiquids) {
         double playerReach = player.worldObj.isRemote
                 ? Minecraft.getMinecraft().playerController.getBlockReachDistance()
-                : (player instanceof EntityPlayerMP
-                        ? ((EntityPlayerMP) player).theItemInWorldManager.getBlockReachDistance()
+                : (player instanceof EntityPlayerMP playerMP ? playerMP.theItemInWorldManager.getBlockReachDistance()
                         : 5.0D);
         return rayTrace(player, playerReach, useLiquids);
     }


### PR DESCRIPTION
Big thanks to Alp for reporting this and context here: https://discord.com/channels/181078474394566657/603348502637969419/1219677017989972010

Apparently the `RIGHT_CLICK_AIR` action during `PlayerInteractEvent` uses the coordinates 0, 0, 0 for vanilla blocks which causes the grief protection to go nuts when the 0, 0 chunk is claimed. Instead of using the unreliable event coords I've changed it to raytrace the block that the player is looking at. A couple events have also got a round of spring cleaning to cut down on duplicated code.




