### PR TITLE
Fix backwards compat not porting chunks if chunk claiming is off

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -173,13 +173,6 @@ public class ServerUtilitiesConfig {
                 "add_nickname_tilde",
                 false,
                 "Adds ~ to player names that have changed nickname to prevent trolling.").getBoolean();
-        // chat.replace_tab_names = config.get(
-        // CHAT,
-        // "replace_tab_names",
-        // false,
-        // "NOT IMPLEMENTED\nDisable this for some plugin compat. Not that they are supported but sometimes this is all
-        // that's needed.")
-        // .getBoolean();
 
         commands.warp = config.get(COMMANDS, "warp", true).getBoolean();
         commands.home = config.get(COMMANDS, "home", true).getBoolean();
@@ -209,16 +202,6 @@ public class ServerUtilitiesConfig {
         login.enable_motd = config.get(LOGIN, "enable_motd", false, "Enables message of the day.").getBoolean();
         login.enable_starting_items = config.get(LOGIN, "enable_starting_items", false, "Enables starting items.")
                 .getBoolean();
-        // login.enable_global_badges = config
-        // .get(
-        // LOGIN,
-        // "enable_global_badges",
-        // true,
-        // "Set to false to disable global badges completely, only server-wide badges will be available.")
-        // .getBoolean();
-        // login.enable_event_badges = config
-        // .get(LOGIN, "enable_event_badges", false, "Set to false to disable event badges, e.g. Halloween.")
-        // .getBoolean();
         login.motd = config.get(
                 LOGIN,
                 "motd",

--- a/src/main/java/serverutils/client/ServerUtilitiesClientConfig.java
+++ b/src/main/java/serverutils/client/ServerUtilitiesClientConfig.java
@@ -75,8 +75,6 @@ public class ServerUtilitiesClientConfig {
                         "Draw dotted lines on loaded chunks to improve noticeability.")
                 .setLanguageKey(CLIENT_LANG_KEY + "show_dotted_lines").getBoolean();
         general.show_shutdown_timer_ms = -1L;
-        // general.render_badges = config.get(Configuration.CATEGORY_GENERAL, "render_badges", false, "Render
-        // badges.").getBoolean();
         general.journeymap_overlay = config.get(
                 Configuration.CATEGORY_GENERAL,
                 "journeymap_overlay",
@@ -121,7 +119,6 @@ public class ServerUtilitiesClientConfig {
 
     public static class General {
 
-        // public boolean render_badges = false;
         public boolean journeymap_overlay;
         public boolean show_shutdown_timer;
         public String shutdown_timer_start;

--- a/src/main/java/serverutils/data/BackwardsCompat.java
+++ b/src/main/java/serverutils/data/BackwardsCompat.java
@@ -82,15 +82,15 @@ public class BackwardsCompat {
     public static void loadChunks() {
         // Loads the chunks from the ClaimedChunks.json file
         // Ignores claim/chunk load limit
-        JsonObject group = JsonUtils.fromJson(new File(Universe.get().latModFolder, "ClaimedChunks.json"))
-                .getAsJsonObject();
+        Universe universe = Universe.get();
+        JsonObject group = JsonUtils.fromJson(new File(universe.latModFolder, "ClaimedChunks.json")).getAsJsonObject();
         if (group == null) return;
-
+        ServerUtilities.LOGGER.info("Loading claimed chunks from LatMod");
+        if (!ClaimedChunks.isActive()) {
+            ClaimedChunks.instance = new ClaimedChunks(universe);
+        }
         for (Map.Entry<String, JsonElement> e : group.entrySet()) {
             int dim = Integer.parseInt(e.getKey());
-            Universe universe = Universe.get();
-            ServerUtilities.LOGGER.info("Loading claimed chunks from LatMod");
-
             for (Map.Entry<String, JsonElement> e1 : e.getValue().getAsJsonObject().entrySet()) {
                 try {
                     ForgePlayer p = Universe.get().getPlayer(StringUtils.fromString(e1.getKey()));
@@ -132,6 +132,7 @@ public class BackwardsCompat {
             }
         }
         ServerUtilities.LOGGER.info("Finished loading claimed chunks from LatMod");
+        ClaimedChunks.instance.forceSave();
     }
 
     public static void loadWarps() {

--- a/src/main/java/serverutils/data/ClaimedChunks.java
+++ b/src/main/java/serverutils/data/ClaimedChunks.java
@@ -44,6 +44,7 @@ public class ClaimedChunks {
     private final Map<ChunkDimPos, ClaimedChunk> map = new HashMap<>();
     public long nextChunkloaderUpdate;
     private boolean isDirty = true;
+    private static boolean forceSave = false;
 
     public ClaimedChunks(Universe u) {
         universe = u;
@@ -64,6 +65,7 @@ public class ClaimedChunks {
         map.clear();
         nextChunkloaderUpdate = 0L;
         isDirty = true;
+        forceSave = false;
     }
 
     public void processQueue() {
@@ -399,5 +401,13 @@ public class ClaimedChunks {
         new ChunkModifiedEvent.Unloaded(chunk, player).post();
         chunk.setLoaded(false);
         return true;
+    }
+
+    public void forceSave() {
+        forceSave = true;
+    }
+
+    public static boolean isForcedToSave() {
+        return instance != null && forceSave;
     }
 }

--- a/src/main/java/serverutils/data/ServerUtilitiesTeamData.java
+++ b/src/main/java/serverutils/data/ServerUtilitiesTeamData.java
@@ -37,7 +37,7 @@ public class ServerUtilitiesTeamData extends TeamData {
 
     @SubscribeEvent
     public void onTeamSaved(ForgeTeamSavedEvent event) {
-        if (!ClaimedChunks.isActive()) {
+        if (!ClaimedChunks.isActive() && !ClaimedChunks.isForcedToSave()) {
             return;
         }
 
@@ -45,7 +45,8 @@ public class ServerUtilitiesTeamData extends TeamData {
 
         Int2ObjectMap<NBTTagList> claimedChunks = new Int2ObjectOpenHashMap<>();
 
-        for (ClaimedChunk chunk : ClaimedChunks.instance.getTeamChunks(event.getTeam(), OptionalInt.empty())) {
+        for (ClaimedChunk chunk : ClaimedChunks.instance
+                .getTeamChunks(event.getTeam(), OptionalInt.empty(), ClaimedChunks.isForcedToSave())) {
             ChunkDimPos pos = chunk.getPos();
 
             NBTTagList list = claimedChunks.get(pos.dim);

--- a/src/main/java/serverutils/data/ServerUtilitiesUniverseData.java
+++ b/src/main/java/serverutils/data/ServerUtilitiesUniverseData.java
@@ -272,7 +272,7 @@ public class ServerUtilitiesUniverseData {
 
     @SubscribeEvent
     public void onUniverseClosed(UniverseClosedEvent event) {
-        if (ClaimedChunks.isActive()) {
+        if (ClaimedChunks.instance != null) {
             ClaimedChunks.instance.clear();
             ClaimedChunks.instance = null;
         }


### PR DESCRIPTION
Oops, that was quite the oversight on my part. 
If chunk claiming is turned off ClaimedChunks will now be instantiated when porting chunks, these chunks won't be processed except to save them to their respective teams.