### PR TITLE
[nbtedit] Allow packets larger than 30000 bytes

### DIFF
--- a/src/main/java/serverutils/client/gui/GuiEditNBT.java
+++ b/src/main/java/serverutils/client/gui/GuiEditNBT.java
@@ -28,7 +28,6 @@ import net.minecraftforge.common.util.Constants;
 
 import it.unimi.dsi.fastutil.bytes.ByteArrayList;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import serverutils.ServerUtilities;
 import serverutils.lib.config.ConfigDouble;
 import serverutils.lib.config.ConfigInt;
 import serverutils.lib.config.ConfigString;
@@ -51,7 +50,6 @@ import serverutils.lib.icon.Icon;
 import serverutils.lib.icon.IconWithBorder;
 import serverutils.lib.icon.ItemIcon;
 import serverutils.lib.item.ItemEntryWithCount;
-import serverutils.lib.util.NBTUtils;
 import serverutils.lib.util.StringUtils;
 import serverutils.lib.util.misc.MouseButton;
 import serverutils.net.MessageEditNBTResponse;
@@ -866,11 +864,7 @@ public class GuiEditNBT extends GuiBase {
         super.onClosed();
 
         if (shouldClose == 1) {
-            if (NBTUtils.getSizeInBytes(buttonNBTRoot.map, false) >= 30000L) {
-                ServerUtilities.LOGGER.error("NBT too large to send!");
-            } else {
-                new MessageEditNBTResponse(info, buttonNBTRoot.map).sendToServer();
-            }
+            new MessageEditNBTResponse(info, buttonNBTRoot.map).sendToServer();
         }
     }
 

--- a/src/main/java/serverutils/command/CmdEditNBT.java
+++ b/src/main/java/serverutils/command/CmdEditNBT.java
@@ -28,7 +28,6 @@ import serverutils.lib.command.CmdTreeHelp;
 import serverutils.lib.command.CommandUtils;
 import serverutils.lib.data.ForgePlayer;
 import serverutils.lib.math.MathUtils;
-import serverutils.lib.util.NBTUtils;
 import serverutils.lib.util.StringUtils;
 import serverutils.net.MessageEditNBT;
 import serverutils.net.MessageEditNBTRequest;
@@ -75,11 +74,7 @@ public class CmdEditNBT extends CmdTreeBase {
             NBTTagCompound info = new NBTTagCompound();
             NBTTagCompound nbt = editNBT(player, info, args);
 
-            long size = NBTUtils.getSizeInBytes(nbt, false);
-
-            if (size >= 30000L) {
-                throw ServerUtilities.error(sender, "commands.nbtedit.too_large");
-            } else if (info.hasKey("type")) {
+            if (info.hasKey("type")) {
                 info.setLong("random", MathUtils.RAND.nextLong());
                 EDITING.put(player.getGameProfile().getId(), info);
                 new MessageEditNBT(info, nbt).sendTo(player);

--- a/src/main/resources/assets/serverutilities/lang/en_US.lang
+++ b/src/main/resources/assets/serverutilities/lang/en_US.lang
@@ -359,7 +359,6 @@ commands.upload_crash_report.usage=/upload_crash_report <file>
 commands.heal.usage=/heal [player]
 commands.killall.usage=/killall [type] [dimension]
 commands.nbtedit.usage=/nbtedit
-commands.nbtedit.too_large=NBT size too large!
 commands.nbtedit.block.usage=/nbtedit block <x> <y> <z>
 commands.nbtedit.entity.usage=/nbtedit entity <id>
 commands.nbtedit.player.usage=/nbtedit player <player>

--- a/src/main/resources/assets/serverutilities/lang/ja_JP.lang
+++ b/src/main/resources/assets/serverutilities/lang/ja_JP.lang
@@ -290,7 +290,6 @@ commands.upload_crash_report.usage=/upload_crash_report <ファイル>
 commands.heal.usage=/heal [プレイヤー]
 commands.killall.usage=/killall [タイプ] [ディメンション]
 commands.nbtedit.usage=/nbtedit
-commands.nbtedit.too_large=NBTのサイズが大きすぎます！
 commands.nbtedit.tile.usage=/nbtedit tile <x> <y> <z>
 commands.nbtedit.entity.usage=/nbtedit entity <id>
 commands.nbtedit.player.usage=/nbtedit player <プレイヤー>

--- a/src/main/resources/assets/serverutilities/lang/ru_RU.lang
+++ b/src/main/resources/assets/serverutilities/lang/ru_RU.lang
@@ -274,7 +274,6 @@ commands.upload_crash_report.usage=/upload_crash_report <file>
 commands.heal.usage=/heal [player]
 commands.killall.usage=/killall [type] [dimension]
 commands.nbtedit.usage=/nbtedit
-commands.nbtedit.too_large=Размер NBT слишком большой!
 commands.nbtedit.tile.usage=/nbtedit tile <x> <y> <z>
 commands.nbtedit.entity.usage=/nbtedit entity <id>
 commands.nbtedit.player.usage=/nbtedit player <player>

--- a/src/main/resources/assets/serverutilities/lang/zh_CN.lang
+++ b/src/main/resources/assets/serverutilities/lang/zh_CN.lang
@@ -275,7 +275,6 @@ commands.upload_crash_report.usage=/upload_crash_report <文件>
 commands.heal.usage=/heal [玩家]
 commands.killall.usage=/killall [类型] [维度]
 commands.nbtedit.usage=/nbtedit
-commands.nbtedit.too_large=NBT 大小过大！
 commands.nbtedit.tile.usage=/nbtedit tile <x> <y> <z>
 commands.nbtedit.entity.usage=/nbtedit entity <id>
 commands.nbtedit.player.usage=/nbtedit player <玩家>


### PR DESCRIPTION
The `/nbtedit player` command is useless with this limitation.
The GTNH modpack allows for packets larger than 30000 bytes anyway, so this restriction is unnecessary.