### PR TITLE
Add factions style team prefix to chat messages

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -64,8 +64,7 @@ public class ServerUtilitiesConfig {
 
         config.setCategoryRequiresWorldRestart(GEN_CAT, true);
 
-        teams.disable_teams = config.get(TEAM_CAT, "disable_teams", false).getBoolean();
-
+        teams.disable_teams = config.get(TEAM_CAT, "disable_teams", false, "Disable teams entirely").getBoolean();
         teams.autocreate_mp = config.get(
                 TEAM_CAT,
                 "autocreate_mp",
@@ -91,6 +90,12 @@ public class ServerUtilitiesConfig {
                 "interaction_protection",
                 true,
                 "Don't allow other players to interact with blocks in claimed chunks").getBoolean();
+        teams.force_team_prefix = config.get(
+                TEAM_CAT,
+                "force_team_prefix",
+                false,
+                "Forces player chat messages to be prefixed with their team name. Example: [Team] <Player> Message")
+                .getBoolean();
 
         config.setCategoryComment(DEBUG_CAT, "Don't set any values to true, unless you are debugging the mod.");
         debugging.special_commands = config.get(DEBUG_CAT, "special_commands", false, "Enables special debug commands.")
@@ -358,6 +363,7 @@ public class ServerUtilitiesConfig {
         public boolean hide_team_notification;
         public boolean grief_protection;
         public boolean interaction_protection;
+        public boolean force_team_prefix;
     }
 
     public static class Debugging {

--- a/src/main/java/serverutils/lib/EnumMessageLocation.java
+++ b/src/main/java/serverutils/lib/EnumMessageLocation.java
@@ -4,7 +4,7 @@ import serverutils.lib.util.misc.NameMap;
 
 public enum EnumMessageLocation {
 
-    OFF("options.narrator.off"),
+    OFF("options.off"),
     CHAT("options.chat.visibility"),
     ACTION_BAR("action_bar");
 

--- a/src/main/resources/assets/serverutilities/lang/en_US.lang
+++ b/src/main/resources/assets/serverutilities/lang/en_US.lang
@@ -233,6 +233,8 @@ player_config.serverutilities.render_badge=Render My Badge
 player_config.serverutilities.enable_pvp=Enable PVP
 player_config.serverutilities.nickname=Nickname
 player_config.serverutilities.afk=AFK Notification Position
+player_config.serverutilities.show_team_prefix=Show Team Prefix In Chat
+player_config.serverutilities.show_team_prefix.info=§rAdd [%s] as a prefix to your chat messages
 
 # Team Settings
 team_config.serverutilities.display=Display


### PR DESCRIPTION
![su_prefix](https://github.com/GTNewHorizons/ServerUtilities/assets/127234178/34d1cf18-646d-40aa-9174-7781b1ab581e)

This is turned off by default but can be toggled by individual players in "My Server Settings" or forced on by the server in config.

In case the player doesn't have any team they'll have this prefix
![su_noteam](https://github.com/GTNewHorizons/ServerUtilities/assets/127234178/5fee6508-af5f-4907-94a7-ae29906c5cd8)
