### PR TITLE
Fix chat formatting parsing

### DIFF
--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -45,12 +45,12 @@ public class ServerUtilitiesServerEventHandler {
 
     public static final ServerUtilitiesServerEventHandler INST = new ServerUtilitiesServerEventHandler();
     private static final ResourceLocation AFK_ID = new ResourceLocation(ServerUtilities.MOD_ID, "afk");
-    private static final Pattern STRIKETHROUGH_PATTERN = Pattern.compile("\\~\\~(.*?)\\~\\~");
+    private static final Pattern STRIKETHROUGH_PATTERN = Pattern.compile("~~(.+?)~~");
     private static final String STRIKETHROUGH_REPLACE = "&m$1&m";
-    private static final Pattern BOLD_PATTERN = Pattern.compile("\\*\\*(.*?)\\*\\*|__(.*?)__");
-    private static final String BOLD_REPLACE = "&l$1$2&l";
-    private static final Pattern ITALIC_PATTERN = Pattern.compile("\\*(.*?)\\*|_(.*?)_");
-    private static final String ITALIC_REPLACE = "&o$1$2&o";
+    private static final Pattern BOLD_PATTERN = Pattern.compile("\\*\\*(.+?)\\*\\*|__(.+?)__");
+    private static final String BOLD_REPLACE = "&l$1&l";
+    private static final Pattern ITALIC_PATTERN = Pattern.compile("\\*(.+?)\\*|_(.+?)_");
+    private static final String ITALIC_REPLACE = "&o$1&o";
 
     @SubscribeEvent
     public void onCacheCleared(UniverseClearCacheEvent event) {
@@ -89,7 +89,7 @@ public class ServerUtilitiesServerEventHandler {
                 message = message.replace(entry.getValue(), "<emoji:" + entry.getKey() + ">");
             }
 
-            b = !message.equals(message = STRIKETHROUGH_PATTERN.matcher(message).replaceAll(STRIKETHROUGH_REPLACE)) | b;
+            b = !message.equals(message = STRIKETHROUGH_PATTERN.matcher(message).replaceAll(STRIKETHROUGH_REPLACE));
             b = !message.equals(message = BOLD_PATTERN.matcher(message).replaceAll(BOLD_REPLACE)) | b;
             b = !message.equals(message = ITALIC_PATTERN.matcher(message).replaceAll(ITALIC_REPLACE)) | b;
 
@@ -206,9 +206,6 @@ public class ServerUtilitiesServerEventHandler {
                         ServerUtilities.LOGGER
                                 .info(player.getDisplayName() + (isAFK ? " is now AFK" : " is no longer AFK"));
 
-                        // if (ServerUtilitiesConfig.chat.replace_tab_names) {
-                        // new MessageUpdateTabName(player).sendToAll();
-                        // }
                     }
 
                     if (playerToKickForAfk == null) {

--- a/src/main/java/serverutils/lib/util/text_components/TextComponentParser.java
+++ b/src/main/java/serverutils/lib/util/text_components/TextComponentParser.java
@@ -16,7 +16,7 @@ import serverutils.lib.util.misc.NameMap;
 
 public class TextComponentParser {
 
-    public static final NameMap.ObjectProperties<EnumChatFormatting> TEXT_FORMATTING_OBJECT_PROPERTIES = new NameMap.ObjectProperties<EnumChatFormatting>() {
+    public static final NameMap.ObjectProperties<EnumChatFormatting> TEXT_FORMATTING_OBJECT_PROPERTIES = new NameMap.ObjectProperties<>() {
 
         @Override
         public String getName(EnumChatFormatting value) {
@@ -170,34 +170,24 @@ public class TextComponentParser {
     private void finishPart() {
         String string = builder.toString();
         builder.setLength(0);
+        if (string.isEmpty()) return;
 
-        if (string.isEmpty()) {
-            return;
-        } else if (string.length() < 2 && string.charAt(0) != '{') {
-            IChatComponent component1 = new ChatComponentText(string);
+        IChatComponent component1 = new ChatComponentText(string);
+        if (string.length() < 2 || string.charAt(0) != '{') {
             component1.setChatStyle(style.createShallowCopy());
             component.appendSibling(component1);
             return;
         }
 
-        IChatComponent component1;
-        if (substitutes == null) {
-            int index = string.indexOf("{");
-            component1 = new ChatComponentText(string.substring(1 + index));
-        } else {
+        if (substitutes != null) {
             component1 = substitutes.apply(string.substring(1));
         }
 
-        if (component1 != null) {
-            ChatStyle style0 = component1.getChatStyle().createShallowCopy();
-            ChatStyle style1 = style.createShallowCopy();
-            style1.setChatHoverEvent(style0.getChatHoverEvent());
-            style1.setChatClickEvent(style0.getChatClickEvent());
-            component1.setChatStyle(style1);
-        } else {
-            throw new IllegalArgumentException("Invalid formatting! Unknown substitute " + string);
-        }
-
+        ChatStyle style0 = component1.getChatStyle().createShallowCopy();
+        ChatStyle style1 = style.createShallowCopy();
+        style1.setChatHoverEvent(style0.getChatHoverEvent());
+        style1.setChatClickEvent(style0.getChatClickEvent());
+        component1.setChatStyle(style1);
         component.appendSibling(component1);
     }
 }

--- a/src/main/java/serverutils/lib/util/text_components/TextComponentParser.java
+++ b/src/main/java/serverutils/lib/util/text_components/TextComponentParser.java
@@ -63,8 +63,8 @@ public class TextComponentParser {
         return new TextComponentParser(text, substitutes).parse();
     }
 
-    private String text;
-    private Function<String, IChatComponent> substitutes;
+    private final String text;
+    private final Function<String, IChatComponent> substitutes;
 
     private IChatComponent component;
     private StringBuilder builder;
@@ -114,57 +114,45 @@ public class TextComponentParser {
             }
 
             if (!escape) {
+                char prev = c[i];
                 if (c[i] == '&') {
                     c[i] = StringUtils.FORMATTING_CHAR;
                 }
 
                 if (c[i] == StringUtils.FORMATTING_CHAR) {
-                    finishPart();
 
-                    if (end) {
-                        throw new IllegalArgumentException(
-                                "Invalid formatting! Can't end string with & or " + StringUtils.FORMATTING_CHAR + "!");
+                    if (end || i + 1 >= c.length) {
+                        builder.append(prev);
+                        break;
                     }
 
-                    i++;
-
-                    EnumChatFormatting formatting = CODE_TO_FORMATTING.get(c[i]);
+                    EnumChatFormatting formatting = CODE_TO_FORMATTING.get(c[i + 1]);
 
                     if (formatting == null) {
-                        throw new IllegalArgumentException(
-                                "Illegal formatting! Unknown color code character: " + c[i] + "!");
+                        builder.append(prev);
+                        continue;
                     }
 
+                    finishPart();
+                    i++;
+
                     switch (formatting) {
-                        case OBFUSCATED:
-                            style.setObfuscated(!style.getObfuscated());
-                            break;
-                        case BOLD:
-                            style.setBold(!style.getBold());
-                            break;
-                        case STRIKETHROUGH:
-                            style.setStrikethrough(!style.getStrikethrough());
-                            break;
-                        case UNDERLINE:
-                            style.setUnderlined(!style.getUnderlined());
-                            break;
-                        case ITALIC:
-                            style.setItalic(!style.getItalic());
-                            break;
-                        case RESET:
-                            style = new ChatStyle();
-                            break;
-                        default:
-                            style.setColor(formatting);
+                        case OBFUSCATED -> style.setObfuscated(!style.getObfuscated());
+                        case BOLD -> style.setBold(!style.getBold());
+                        case STRIKETHROUGH -> style.setStrikethrough(!style.getStrikethrough());
+                        case UNDERLINE -> style.setUnderlined(!style.getUnderlined());
+                        case ITALIC -> style.setItalic(!style.getItalic());
+                        case RESET -> style = new ChatStyle();
+                        default -> style.setColor(formatting);
                     }
 
                     continue;
                 } else if (c[i] == '{') {
-                    finishPart();
-
                     if (end) {
-                        throw new IllegalArgumentException("Invalid formatting! Can't end string with {!");
+                        builder.append(c[i]);
+                        break;
                     }
+                    finishPart();
 
                     sub = true;
                 }
@@ -185,14 +173,20 @@ public class TextComponentParser {
 
         if (string.isEmpty()) {
             return;
-        } else if (string.length() < 2 || string.charAt(0) != '{') {
+        } else if (string.length() < 2 && string.charAt(0) != '{') {
             IChatComponent component1 = new ChatComponentText(string);
             component1.setChatStyle(style.createShallowCopy());
             component.appendSibling(component1);
             return;
         }
 
-        IChatComponent component1 = substitutes.apply(string.substring(1));
+        IChatComponent component1;
+        if (substitutes == null) {
+            int index = string.indexOf("{");
+            component1 = new ChatComponentText(string.substring(1 + index));
+        } else {
+            component1 = substitutes.apply(string.substring(1));
+        }
 
         if (component1 != null) {
             ChatStyle style0 = component1.getChatStyle().createShallowCopy();


### PR DESCRIPTION
Supersedes https://github.com/GTNewHorizons/ServerUtilities/pull/83 and 
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16422

Fixes the problem by not trying to apply formatting if there is no valid one. Also stops "\*\*" and "****" from being replaced if there are no characters in between the asterisks.

~~Beforehand bold and italics couldn't be present in the same string so for the funsies I made it accept nested formatting so that "\~\~\*\*{\*Insert string here\*}**\~~\" will be strikethrough, bold and italics.~~
Nvm that worked without the brackets before lol.