### PR TITLE
Fix crash when creating a new world

### DIFF
--- a/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
@@ -208,7 +208,7 @@ public class ServerUtilitiesPlayerEventHandler {
     public void onNameFormat(PlayerEvent.NameFormat event) {
         if (!(event.entityPlayer instanceof EntityPlayerMP player) || ServerUtils.isFake(player)) return;
         if (ServerUtilitiesConfig.commands.nick && Universe.loaded()) {
-            ForgePlayer p = Universe.get().getPlayer(player);
+            ForgePlayer p = Universe.get().getPlayer(player.getGameProfile());
 
             if (p != null) {
                 ServerUtilitiesPlayerData data = ServerUtilitiesPlayerData.get(p);


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/ServerUtilities/issues/86

The crash was introduced in https://github.com/GTNewHorizons/ServerUtilities/pull/82 which I didn't notice as it only happens when creating a new world/a new player joining a server. The reason this happens is because `PlayerEvent.NameFormat` is sent prior to `PlayerEvent.PlayerLoggedInEvent` which means the player won't necessarily be registered yet.
Switching getPlayer back to the nullable version solves it.