### PR TITLE
Add command overview gui

### DIFF
--- a/src/main/java/serverutils/client/gui/GuiClientConfig.java
+++ b/src/main/java/serverutils/client/gui/GuiClientConfig.java
@@ -4,7 +4,8 @@ import java.util.List;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
-import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.init.Items;
+import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.config.ConfigElement;
 import net.minecraftforge.common.config.Configuration;
 
@@ -22,8 +23,10 @@ import serverutils.lib.gui.WidgetType;
 import serverutils.lib.gui.misc.GuiButtonListBase;
 import serverutils.lib.gui.misc.GuiLoading;
 import serverutils.lib.icon.Icon;
+import serverutils.lib.icon.ItemIcon;
 import serverutils.lib.util.SidedUtils;
 import serverutils.lib.util.misc.MouseButton;
+import serverutils.net.MessageCommandsRequest;
 
 public class GuiClientConfig extends GuiButtonListBase {
 
@@ -82,13 +85,33 @@ public class GuiClientConfig extends GuiButtonListBase {
         panel.add(
                 new SimpleTextButton(
                         panel,
-                        new ChatComponentTranslation("serverutilities_client").getUnformattedText(),
+                        StatCollector.translateToLocal("serverutilities_client"),
                         Icon.getIcon("serverutilities:textures/logo_small.png")) {
 
                     @Override
                     public void onClicked(MouseButton button) {
                         GuiHelper.playClickSound();
                         Minecraft.getMinecraft().displayGuiScreen(new GuiCustomConfig(getTitle()));
+                    }
+                });
+
+        panel.add(
+                new SimpleTextButton(
+                        panel,
+                        StatCollector.translateToLocal("serverutilities.command_overview"),
+                        ItemIcon.getItemIcon(Items.compass)) {
+
+                    @Override
+                    public void onClicked(MouseButton button) {
+                        GuiHelper.playClickSound();
+                        new GuiLoading().openGui();
+                        new MessageCommandsRequest().sendToServer();
+                    }
+
+                    @Override
+                    public WidgetType getWidgetType() {
+                        return SidedUtils.isModLoadedOnServer(ServerUtilities.MOD_ID) ? super.getWidgetType()
+                                : WidgetType.DISABLED;
                     }
                 });
     }

--- a/src/main/java/serverutils/client/gui/GuiViewCommands.java
+++ b/src/main/java/serverutils/client/gui/GuiViewCommands.java
@@ -1,0 +1,57 @@
+package serverutils.client.gui;
+
+import java.util.List;
+import java.util.Map;
+
+import net.minecraft.util.IChatComponent;
+
+import serverutils.lib.client.ClientUtils;
+import serverutils.lib.gui.GuiHelper;
+import serverutils.lib.gui.Panel;
+import serverutils.lib.gui.SimpleTextButton;
+import serverutils.lib.gui.misc.GuiButtonListBase;
+import serverutils.lib.icon.Icon;
+import serverutils.lib.util.misc.MouseButton;
+
+public class GuiViewCommands extends GuiButtonListBase {
+
+    private final Map<String, IChatComponent> commands;
+
+    public GuiViewCommands(Map<String, IChatComponent> commands) {
+        this.commands = commands;
+        setHasSearchBox(true);
+    }
+
+    @Override
+    public void addButtons(Panel panel) {
+        commands.entrySet().stream().sorted(Map.Entry.comparingByKey())
+                .forEachOrdered(entry -> panel.add(new CommandEntry(panel, entry.getKey(), entry.getValue())));
+    }
+
+    public static class CommandEntry extends SimpleTextButton {
+
+        private final IChatComponent description;
+
+        public CommandEntry(Panel panel, String title, IChatComponent description) {
+            super(panel, title, Icon.EMPTY);
+            this.description = description;
+            setSize(16, 14);
+        }
+
+        @Override
+        public void onClicked(MouseButton button) {
+            GuiHelper.playClickSound();
+            ClientUtils.execClientCommand("/" + getTitle());
+        }
+
+        @Override
+        public void addMouseOverText(List<String> list) {
+            list.addAll(getGui().getTheme().listFormattedStringToWidth(description.getFormattedText(), 200));
+        }
+
+        @Override
+        public boolean renderTitleInCenter() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/serverutils/client/gui/GuiViewCrashList.java
+++ b/src/main/java/serverutils/client/gui/GuiViewCrashList.java
@@ -40,7 +40,7 @@ public class GuiViewCrashList extends GuiButtonListBase {
     @Override
     public String getTitle() {
         return I18n.format("sidebar_button.serverutilities.admin_panel") + " > "
-                + I18n.format("admin_panel.serverutilities.crash_reports");
+                + I18n.format("serverutilities.admin_panel.crash_reports");
     }
 
     @Override

--- a/src/main/java/serverutils/handlers/ServerUtilitiesRegistryEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesRegistryEventHandler.java
@@ -65,7 +65,7 @@ public class ServerUtilitiesRegistryEventHandler {
                     @Override
                     public void onAction(ForgePlayer player, NBTTagCompound data) {
                         ConfigGroup main = ConfigGroup.newGroup("edit_world");
-                        main.setDisplayName(new ChatComponentTranslation("admin_panel.serverutilities.edit_world"));
+                        main.setDisplayName(new ChatComponentTranslation("serverutilities.admin_panel.edit_world"));
 
                         if (player.hasPermission(ServerUtilitiesPermissions.EDIT_WORLD_GAMERULES)) {
                             ConfigGroup gamerules = main.getGroup("gamerules");

--- a/src/main/java/serverutils/lib/command/CommandUtils.java
+++ b/src/main/java/serverutils/lib/command/CommandUtils.java
@@ -1,14 +1,19 @@
 package serverutils.lib.command;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.OptionalInt;
+import java.util.Set;
 
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommand;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.PlayerSelector;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.IChatComponent;
 import net.minecraftforge.common.DimensionManager;
@@ -151,5 +156,32 @@ public class CommandUtils {
             case "all", "*" -> OptionalInt.empty();
             default -> OptionalInt.of(CommandBase.parseInt(sender, args[index]));
         };
+    }
+
+    public static IChatComponent getTranslatedUsage(ICommand command, ICommandSender sender) {
+        String usageS = command.getCommandUsage(sender);
+        IChatComponent usage;
+        if (usageS == null || usageS.isEmpty()
+                || usageS.indexOf('/') != -1
+                || usageS.indexOf('%') != -1
+                || usageS.indexOf(' ') != -1) {
+            usage = new ChatComponentText(usageS);
+        } else {
+            usage = new ChatComponentTranslation(usageS);
+        }
+        return usage;
+    }
+
+    public static List<ICommand> getAllCommands(ICommandSender sender) {
+        ArrayList<ICommand> commands = new ArrayList<>();
+        Set<String> cmdIds = new HashSet<>();
+
+        for (ICommand cmd : ServerUtils.getServer().getCommandManager().getPossibleCommands(sender)) {
+            if (cmdIds.add(cmd.getCommandName())) {
+                commands.add(cmd);
+            }
+        }
+
+        return commands;
     }
 }

--- a/src/main/java/serverutils/net/MessageCommandsRequest.java
+++ b/src/main/java/serverutils/net/MessageCommandsRequest.java
@@ -1,0 +1,19 @@
+package serverutils.net;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+
+import serverutils.lib.net.MessageToServer;
+import serverutils.lib.net.NetworkWrapper;
+
+public class MessageCommandsRequest extends MessageToServer {
+
+    @Override
+    public NetworkWrapper getWrapper() {
+        return ServerUtilitiesNetHandler.GENERAL;
+    }
+
+    @Override
+    public void onMessage(EntityPlayerMP player) {
+        new MessageCommandsResponse(player).sendTo(player);
+    }
+}

--- a/src/main/java/serverutils/net/MessageCommandsResponse.java
+++ b/src/main/java/serverutils/net/MessageCommandsResponse.java
@@ -1,0 +1,69 @@
+package serverutils.net;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.command.ICommand;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.IChatComponent;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import serverutils.client.gui.GuiViewCommands;
+import serverutils.lib.command.CommandTreeBase;
+import serverutils.lib.command.CommandUtils;
+import serverutils.lib.io.DataIn;
+import serverutils.lib.io.DataOut;
+import serverutils.lib.net.MessageToClient;
+import serverutils.lib.net.NetworkWrapper;
+
+public class MessageCommandsResponse extends MessageToClient {
+
+    private Map<String, IChatComponent> commands;
+
+    public MessageCommandsResponse() {}
+
+    public MessageCommandsResponse(EntityPlayerMP player) {
+        commands = new HashMap<>();
+        for (ICommand command : CommandUtils.getAllCommands(player)) {
+            IChatComponent usage = CommandUtils.getTranslatedUsage(command, player);
+            if (command instanceof CommandTreeBase cmdTree) {
+                StringBuilder builder = new StringBuilder();
+                builder.append(" [");
+                for (ICommand subCommand : cmdTree.getSubCommands()) {
+                    builder.append(subCommand.getCommandName()).append("|");
+                }
+                int index = builder.lastIndexOf("|");
+                if (index != -1) {
+                    builder.deleteCharAt(index);
+                }
+                builder.append("]");
+                IChatComponent subCommands = new ChatComponentText(builder.toString());
+                usage.appendSibling(subCommands);
+            }
+            commands.put(command.getCommandName(), usage);
+        }
+    }
+
+    @Override
+    public NetworkWrapper getWrapper() {
+        return ServerUtilitiesNetHandler.GENERAL;
+    }
+
+    @Override
+    public void writeData(DataOut data) {
+        data.writeMap(commands, DataOut.STRING, DataOut.TEXT_COMPONENT);
+    }
+
+    @Override
+    public void readData(DataIn data) {
+        commands = data.readMap(DataIn.STRING, DataIn.TEXT_COMPONENT);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void onMessage() {
+        new GuiViewCommands(commands).openGui();
+    }
+}

--- a/src/main/java/serverutils/net/MessageRanks.java
+++ b/src/main/java/serverutils/net/MessageRanks.java
@@ -18,6 +18,7 @@ import serverutils.ServerUtilitiesConfig;
 import serverutils.client.gui.ranks.GuiRanks;
 import serverutils.client.gui.ranks.RankInst;
 import serverutils.data.NodeEntry;
+import serverutils.lib.command.CommandUtils;
 import serverutils.lib.config.ConfigBoolean;
 import serverutils.lib.config.ConfigGroup;
 import serverutils.lib.config.ConfigValue;
@@ -68,7 +69,7 @@ public class MessageRanks extends MessageToClient {
                     defaultValue = new ConfigBoolean(cmd.getRequiredPermissionLevel() == 0);
                     group.add(permissionNode, val, defaultValue, StringUtils.FLAG_ID_PERIOD_DEFAULTS)
                             .setDisplayName(new ChatComponentTranslation(permissionNode))
-                            .setInfo(cmd.getTranslatedUsage(p.getPlayer()));
+                            .setInfo(CommandUtils.getTranslatedUsage(cmd, p.getPlayer()));
                 } else {
                     group.add(permissionNode, val, defaultValue, StringUtils.FLAG_ID_PERIOD_DEFAULTS)
                             .setDisplayName(new ChatComponentTranslation(permissionNode));
@@ -142,7 +143,7 @@ public class MessageRanks extends MessageToClient {
 
                     commandPermissions.add(commandNode, val, val, StringUtils.FLAG_ID_PERIOD_DEFAULTS)
                             .setDisplayName(new ChatComponentTranslation(commandNode))
-                            .setInfo(command.getTranslatedUsage(p.getPlayer()));
+                            .setInfo(CommandUtils.getTranslatedUsage(command, p.getPlayer()));
                 }
             }
         }

--- a/src/main/java/serverutils/net/ServerUtilitiesNetHandler.java
+++ b/src/main/java/serverutils/net/ServerUtilitiesNetHandler.java
@@ -22,6 +22,8 @@ public class ServerUtilitiesNetHandler {
         GENERAL.register(new MessageAdminPanelAction());
         GENERAL.register(new MessageUpdateTabName());
         GENERAL.register(new MessageUpdatePlayTime());
+        GENERAL.register(new MessageCommandsResponse());
+        GENERAL.register(new MessageCommandsRequest());
 
         CLAIMS.register(new MessageClaimedChunksRequest());
         CLAIMS.register(new MessageClaimedChunksUpdate());

--- a/src/main/java/serverutils/ranks/CommandOverride.java
+++ b/src/main/java/serverutils/ranks/CommandOverride.java
@@ -9,9 +9,6 @@ import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommand;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.util.ChatComponentText;
-import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.util.IChatComponent;
 
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.eventhandler.Event;
@@ -29,27 +26,12 @@ public class CommandOverride extends CommandBase {
 
     public final ICommand mirrored;
     public final String node;
-    // public final IChatComponent usage;
     public final ModContainer modContainer;
 
     private CommandOverride(ICommand c, String parent, @Nullable ModContainer container) {
         mirrored = c;
         node = parent + '.' + mirrored.getCommandName();
         Ranks.INSTANCE.commands.put(node, this);
-
-        // TODO: Fix crash with other mods
-
-        // String usageS = getCommandUsage(FakePlayerFactory.getMinecraft(Ranks.INSTANCE.universe.world));
-        //
-        // if (usageS == null || usageS.isEmpty()
-        // || usageS.indexOf('/') != -1
-        // || usageS.indexOf('%') != -1
-        // || usageS.indexOf(' ') != -1) {
-        // usage = new ChatComponentText(usageS);
-        // } else {
-        // usage = new ChatComponentTranslation(usageS);
-        // }
-
         modContainer = container;
     }
 
@@ -105,19 +87,5 @@ public class CommandOverride extends CommandBase {
     public int compareTo(ICommand o) {
         return o instanceof CommandOverride override ? node.compareTo(override.node)
                 : getCommandName().compareTo(o.getCommandName());
-    }
-
-    public IChatComponent getTranslatedUsage(ICommandSender sender) {
-        String usageS = getCommandUsage(sender);
-        IChatComponent usage;
-        if (usageS == null || usageS.isEmpty()
-                || usageS.indexOf('/') != -1
-                || usageS.indexOf('%') != -1
-                || usageS.indexOf(' ') != -1) {
-            usage = new ChatComponentText(usageS);
-        } else {
-            usage = new ChatComponentTranslation(usageS);
-        }
-        return usage;
     }
 }

--- a/src/main/resources/assets/serverutilities/lang/en_US.lang
+++ b/src/main/resources/assets/serverutilities/lang/en_US.lang
@@ -20,6 +20,7 @@ serverutilities.disabled.server=Disabled by server
 serverutilities.vp.button=Show Server Utilities Claims Overlay
 serverutilities.unsaved_changes.title=Unsaved Changes
 serverutilities.unsaved_changes=You have unsaved changes. Do you want to save them?
+serverutilities.command_overview=Command Overview
 
 serverutilities.stat.dph=Deaths Per Hour
 serverutilities.stat.last_seen=Last Seen


### PR DESCRIPTION
A quick implementation of Ethryan's suggestion here https://github.com/GTNewHorizons/ServerUtilities/pull/88#pullrequestreview-2122723689.

It'll show all the commands that the player can use along with their usage. You can also search for specific commands which saves you going through 30 pages of /help.
![su_cmd_overview](https://github.com/GTNewHorizons/ServerUtilities/assets/127234178/b6194662-0d4b-4e22-8bc8-265398899921)
