### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -17,12 +17,7 @@
       "credits": "GTNH",
       "logoFile": "",
       "screenshots": [],
-      "parent": "",
-      "dependencies": [
-        "Baubles",
-        "Waila"
-      ],
-      "useDependencyInformation": true
+      "parent": ""
     }
   ]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.