### PR TITLE
Keep track of AFK time in statistics, and display AFK-related leaderboards

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesCommon.java
+++ b/src/main/java/serverutils/ServerUtilitiesCommon.java
@@ -147,6 +147,7 @@ public class ServerUtilitiesCommon {
             PermissionAPI.setPermissionHandler(ServerUtilitiesPermissionHandler.INSTANCE);
         }
 
+        ServerUtilitiesStats.init();
         ServerUtilitiesNetHandler.init();
 
         if (!ForgeChunkManager.getConfig().hasCategory(ServerUtilities.MOD_ID)) {

--- a/src/main/java/serverutils/ServerUtilitiesLeaderboards.java
+++ b/src/main/java/serverutils/ServerUtilitiesLeaderboards.java
@@ -68,8 +68,8 @@ public class ServerUtilitiesLeaderboards {
                                 return component;
                             } else {
                                 long worldTime = player.team.universe.world.getTotalWorldTime();
-                                int time = (int) (worldTime - player.getLastTimeSeen());
-                                return Leaderboard.FromStat.TIME.apply(time);
+                                long time = worldTime - player.getLastTimeSeen();
+                                return Leaderboard.FromStat.LONG_TIME.apply(time);
                             }
                         },
                         Comparator.comparingLong(ServerUtilitiesLeaderboards::getRelativeLastSeen),

--- a/src/main/java/serverutils/ServerUtilitiesStats.java
+++ b/src/main/java/serverutils/ServerUtilitiesStats.java
@@ -1,0 +1,20 @@
+package serverutils;
+
+import net.minecraft.stats.StatBase;
+import net.minecraft.stats.StatBasic;
+import net.minecraft.util.ChatComponentTranslation;
+
+public final class ServerUtilitiesStats {
+
+    private ServerUtilitiesStats() {}
+
+    public static final StatBase AFK_TIME = (new StatBasic(
+            "serverutilities.stat.time_afk",
+            new ChatComponentTranslation("serverutilities.stat.time_afk"),
+            StatBase.timeStatType)).initIndependentStat().registerStat();
+
+    /** Ensures the class is loaded and all stats are registered */
+    public static void init() {
+        // no-op
+    }
+}

--- a/src/main/java/serverutils/data/Leaderboard.java
+++ b/src/main/java/serverutils/data/Leaderboard.java
@@ -3,6 +3,7 @@ package serverutils.data;
 import java.util.Comparator;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+import java.util.function.LongFunction;
 import java.util.function.Predicate;
 
 import net.minecraft.stats.StatBase;
@@ -54,6 +55,8 @@ public class Leaderboard {
                 value <= 0 ? "0" : Integer.toString(value));
         public static final IntFunction<IChatComponent> TIME = value -> new ChatComponentText(
                 "[" + (int) (value / 72000D + 0.5D) + "h] " + Ticks.get(value).toTimeString());
+        public static final LongFunction<IChatComponent> LONG_TIME = value -> new ChatComponentText(
+                "[" + (long) (value / 72000D + 0.5D) + "h] " + Ticks.get(value).toTimeString());
 
         public FromStat(ResourceLocation id, IChatComponent t, StatBase statBase, boolean from0to1,
                 IntFunction<IChatComponent> valueToString) {

--- a/src/main/java/serverutils/data/Leaderboard.java
+++ b/src/main/java/serverutils/data/Leaderboard.java
@@ -1,6 +1,7 @@
 package serverutils.data;
 
 import java.util.Comparator;
+import java.util.function.DoubleFunction;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.LongFunction;
@@ -53,6 +54,8 @@ public class Leaderboard {
 
         public static final IntFunction<IChatComponent> DEFAULT = value -> new ChatComponentText(
                 value <= 0 ? "0" : Integer.toString(value));
+        public static final DoubleFunction<IChatComponent> PERCENTAGE = value -> new ChatComponentText(
+                String.format("%.2f%%", value * 100.0));
         public static final IntFunction<IChatComponent> TIME = value -> new ChatComponentText(
                 "[" + (int) (value / 72000D + 0.5D) + "h] " + Ticks.get(value).toTimeString());
         public static final LongFunction<IChatComponent> LONG_TIME = value -> new ChatComponentText(

--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -22,6 +22,7 @@ import serverutils.ServerUtilities;
 import serverutils.ServerUtilitiesCommon;
 import serverutils.ServerUtilitiesConfig;
 import serverutils.ServerUtilitiesPermissions;
+import serverutils.ServerUtilitiesStats;
 import serverutils.data.ClaimedChunks;
 import serverutils.data.ServerUtilitiesPlayerData;
 import serverutils.data.ServerUtilitiesUniverseData;
@@ -179,6 +180,10 @@ public class ServerUtilitiesServerEventHandler {
                     boolean prevIsAfk = data.afkTime >= ServerUtilitiesConfig.afk.getNotificationTimer();
                     data.afkTime = System.currentTimeMillis() - player.func_154331_x();
                     boolean isAFK = data.afkTime >= ServerUtilitiesConfig.afk.getNotificationTimer();
+
+                    if (isAFK) {
+                        player.addStat(ServerUtilitiesStats.AFK_TIME, 1);
+                    }
 
                     if (prevIsAfk != isAFK) {
                         for (EntityPlayerMP player1 : universe.server.getConfigurationManager().playerEntityList) {

--- a/src/main/resources/assets/serverutilities/lang/en_US.lang
+++ b/src/main/resources/assets/serverutilities/lang/en_US.lang
@@ -22,6 +22,9 @@ serverutilities.unsaved_changes.title=Unsaved Changes
 serverutilities.unsaved_changes=You have unsaved changes. Do you want to save them?
 serverutilities.command_overview=Command Overview
 
+serverutilities.stat.time_afk=Time AFK
+serverutilities.stat.time_afk_percent=Percentage of time spent AFK
+serverutilities.stat.time_active=Time actively playing (not AFK)
 serverutilities.stat.dph=Deaths Per Hour
 serverutilities.stat.last_seen=Last Seen
 


### PR DESCRIPTION
- Fix an integer overflow with very large "Last seen" stats as that can easily overflow if the server runs 24/7
- Add a new statistic "AFK time" counting up the game ticks spent AFK, to match the vanilla playtime statistic
- Display AFK time, Active (not AFK) time and percentage of AFK/Total playtime in three leader(shame)boards
![2024-07-17_19 39 01](https://github.com/user-attachments/assets/e3b3845c-3031-4357-9d06-131d0145620d)
![2024-07-17_19 39 07](https://github.com/user-attachments/assets/1e8efd0e-7219-4861-94cf-8c3757501cc1)
![2024-07-17_19 39 11](https://github.com/user-attachments/assets/de000a19-9435-4820-9d74-a580f82ff9e2)
![2024-07-17_19 51 31](https://github.com/user-attachments/assets/4957a445-a354-4437-bea2-1e751c67a5c2)
