### PR TITLE
Includes the leadup afk duration to AFK timer

### DIFF
--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -1,5 +1,7 @@
 package serverutils.handlers;
 
+import static net.minecraft.realms.RealmsMth.floor;
+
 import java.util.Map;
 import java.util.regex.Pattern;
 

--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -183,7 +183,9 @@ public class ServerUtilitiesServerEventHandler {
 
                     if (isAFK) {
                         if (!prevIsAfk) {
-                            player.addStat(ServerUtilitiesStats.AFK_TIME, floor(ServerUtilitiesConfig.afk.getNotificationTimer() / 50));//Millisec to ticks
+                            player.addStat(
+                                    ServerUtilitiesStats.AFK_TIME,
+                                    floor(ServerUtilitiesConfig.afk.getNotificationTimer() / 50));// Millisec to ticks
                         } else {
                             player.addStat(ServerUtilitiesStats.AFK_TIME, 1);
                         }

--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -182,7 +182,11 @@ public class ServerUtilitiesServerEventHandler {
                     boolean isAFK = data.afkTime >= ServerUtilitiesConfig.afk.getNotificationTimer();
 
                     if (isAFK) {
-                        player.addStat(ServerUtilitiesStats.AFK_TIME, 1);
+                        if (!prevIsAfk) {
+                            player.addStat(ServerUtilitiesStats.AFK_TIME, floor(ServerUtilitiesConfig.afk.getNotificationTimer() / 50));//Millisec to ticks
+                        } else {
+                            player.addStat(ServerUtilitiesStats.AFK_TIME, 1);
+                        }
                     }
 
                     if (prevIsAfk != isAFK) {


### PR DESCRIPTION
Example: afk timer is set at 30min and the player is afk for 45 min. the resulting statistics would be 15min without this modification and 45 with it.