### PR TITLE
Change /back to work like essentials

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesPermissions.java
+++ b/src/main/java/serverutils/ServerUtilitiesPermissions.java
@@ -176,7 +176,7 @@ public class ServerUtilitiesPermissions {
                 "Keep loaded chunks working when player goes offline");
         PermissionAPI.registerNode(
                 INFINITE_BACK_USAGE,
-                DefaultPermissionLevel.NONE,
+                DefaultPermissionLevel.ALL,
                 "Allow to use 'back' command infinite times");
         PermissionAPI.registerNode(
                 CRASH_REPORTS_VIEW,

--- a/src/main/java/serverutils/command/tp/CmdBack.java
+++ b/src/main/java/serverutils/command/tp/CmdBack.java
@@ -33,7 +33,7 @@ public class CmdBack extends CmdBase {
         TeleportLog lastTeleportLog = data.getLastTeleportLog();
 
         if (lastTeleportLog == null) {
-            throw ServerUtilities.error(sender, "serverutilities.lang.warps.no_dp");
+            throw ServerUtilities.error(sender, "serverutilities.lang.warps.no_pos_found");
         }
 
         BlockDimPos noPosFound = new BlockDimPos(0, 0, 0, 0);
@@ -43,18 +43,6 @@ public class CmdBack extends CmdBase {
 
         data.checkTeleportCooldown(sender, ServerUtilitiesPlayerData.Timer.BACK);
 
-        Task task = new Task() {
-
-            @Override
-            public void execute(Universe universe) {
-                if (!PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.INFINITE_BACK_USAGE)) {
-                    for (TeleportType t : TeleportType.values()) {
-                        data.clearLastTeleport(t);
-                    }
-                }
-            }
-        };
-
-        ServerUtilitiesPlayerData.Timer.BACK.teleport(player, playerMP -> lastTeleportLog.teleporter(), task);
+        ServerUtilitiesPlayerData.Timer.BACK.teleport(player, playerMP -> lastTeleportLog.teleporter(), null);
     }
 }

--- a/src/main/java/serverutils/command/tp/CmdBack.java
+++ b/src/main/java/serverutils/command/tp/CmdBack.java
@@ -5,12 +5,17 @@ import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayerMP;
 
 import serverutils.ServerUtilities;
+import serverutils.ServerUtilitiesPermissions;
 import serverutils.data.ServerUtilitiesPlayerData;
 import serverutils.data.TeleportLog;
+import serverutils.data.TeleportType;
 import serverutils.lib.command.CmdBase;
 import serverutils.lib.command.CommandUtils;
 import serverutils.lib.data.ForgePlayer;
+import serverutils.lib.data.Universe;
 import serverutils.lib.math.BlockDimPos;
+import serverutils.lib.util.permission.PermissionAPI;
+import serverutils.task.Task;
 
 public class CmdBack extends CmdBase {
 

--- a/src/main/java/serverutils/command/tp/CmdBack.java
+++ b/src/main/java/serverutils/command/tp/CmdBack.java
@@ -33,7 +33,7 @@ public class CmdBack extends CmdBase {
         TeleportLog lastTeleportLog = data.getLastTeleportLog();
 
         if (lastTeleportLog == null) {
-            throw ServerUtilities.error(sender, "serverutilities.lang.warps.no_pos_found");
+            throw ServerUtilities.error(sender, "serverutilities.lang.warps.no_dp");
         }
 
         BlockDimPos noPosFound = new BlockDimPos(0, 0, 0, 0);
@@ -43,6 +43,18 @@ public class CmdBack extends CmdBase {
 
         data.checkTeleportCooldown(sender, ServerUtilitiesPlayerData.Timer.BACK);
 
-        ServerUtilitiesPlayerData.Timer.BACK.teleport(player, playerMP -> lastTeleportLog.teleporter(), null);
+        Task task = new Task() {
+
+            @Override
+            public void execute(Universe universe) {
+                if (!PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.INFINITE_BACK_USAGE)) {
+                    for (TeleportType t : TeleportType.values()) {
+                        data.clearLastTeleport(t);
+                    }
+                }
+            }
+        };
+
+        ServerUtilitiesPlayerData.Timer.BACK.teleport(player, playerMP -> lastTeleportLog.teleporter(), task);
     }
 }


### PR DESCRIPTION
Allows cyclic /back's to go back and forth, just as essentials has done for 10+ years. Much more convenient.