### PR TITLE
Customizable stat leaderboards

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesCommon.java
+++ b/src/main/java/serverutils/ServerUtilitiesCommon.java
@@ -177,7 +177,6 @@ public class ServerUtilitiesCommon {
         MinecraftForge.EVENT_BUS.register(ServerUtilitiesWorldEventHandler.INST);
         MinecraftForge.EVENT_BUS.register(ServerUtilitiesUniverseData.INST);
         MinecraftForge.EVENT_BUS.register(ServerUtilitiesPermissions.INST);
-        MinecraftForge.EVENT_BUS.register(ServerUtilitiesLeaderboards.INST);
         FMLCommonHandler.instance().bus().register(ServerUtilitiesServerEventHandler.INST);
         if (AuroraConfig.enable) {
             MinecraftForge.EVENT_BUS.register(AuroraMinecraftHandler.INST);
@@ -281,6 +280,7 @@ public class ServerUtilitiesCommon {
         Universe.onServerAboutToStart(event);
         MinecraftForge.EVENT_BUS.register(Universe.get());
         FMLCommonHandler.instance().bus().register(Universe.get());
+        ServerUtilitiesLeaderboards.loadLeaderboards();
     }
 
     public void onServerStarting(FMLServerStartingEvent event) {

--- a/src/main/java/serverutils/ServerUtilitiesCommon.java
+++ b/src/main/java/serverutils/ServerUtilitiesCommon.java
@@ -50,7 +50,6 @@ import serverutils.data.ServerUtilitiesLoadedChunkManager;
 import serverutils.data.ServerUtilitiesUniverseData;
 import serverutils.events.CustomPermissionPrefixesRegistryEvent;
 import serverutils.events.IReloadHandler;
-import serverutils.events.LeaderboardRegistryEvent;
 import serverutils.events.ServerReloadEvent;
 import serverutils.events.ServerUtilitiesPreInitRegistryEvent;
 import serverutils.handlers.ServerUtilitiesPlayerEventHandler;
@@ -186,9 +185,7 @@ public class ServerUtilitiesCommon {
     }
 
     public void init(FMLInitializationEvent event) {
-        new LeaderboardRegistryEvent(leaderboard -> LEADERBOARDS.put(leaderboard.id, leaderboard)).post();
         ServerUtilitiesPermissions.registerPermissions();
-
         ServerUtilitiesPreInitRegistryEvent.Registry registry = new ServerUtilitiesPreInitRegistryEvent.Registry() {
 
             @Override

--- a/src/main/java/serverutils/ServerUtilitiesCommon.java
+++ b/src/main/java/serverutils/ServerUtilitiesCommon.java
@@ -108,7 +108,6 @@ import serverutils.task.backup.BackupTask;
 public class ServerUtilitiesCommon {
 
     public static final Collection<NodeEntry> CUSTOM_PERM_PREFIX_REGISTRY = new HashSet<>();
-    public static final Map<ResourceLocation, Leaderboard> LEADERBOARDS = new HashMap<>();
     public static final Map<String, String> KAOMOJIS = new HashMap<>();
     public static final Map<String, ConfigValueProvider> CONFIG_VALUE_PROVIDERS = new HashMap<>();
     public static final Map<UUID, ServerUtilitiesCommon.EditingConfig> TEMP_SERVER_CONFIG = new HashMap<>();
@@ -260,7 +259,7 @@ public class ServerUtilitiesCommon {
         registry.registerTeamAction(ServerUtilitiesTeamGuiActions.TRANSFER_OWNERSHIP);
 
         new ServerUtilitiesPreInitRegistryEvent(registry).post();
-
+        RELOAD_IDS.put(new ResourceLocation(ServerUtilities.MOD_ID, "internal_reload"), this::onReload);
         RankConfigAPI.getHandler();
 
         CHAT_FORMATTING_SUBSTITUTES.put("name", ForgePlayer::getDisplayName);
@@ -277,7 +276,6 @@ public class ServerUtilitiesCommon {
         Universe.onServerAboutToStart(event);
         MinecraftForge.EVENT_BUS.register(Universe.get());
         FMLCommonHandler.instance().bus().register(Universe.get());
-        ServerUtilitiesLeaderboards.loadLeaderboards();
     }
 
     public void onServerStarting(FMLServerStartingEvent event) {
@@ -351,6 +349,13 @@ public class ServerUtilitiesCommon {
                 && (auto_shutdown.enabled_singleplayer || universe.server.isDedicatedServer())) {
             universe.scheduleTask(new ShutdownTask());
         }
+    }
+
+    public boolean onReload(ServerReloadEvent event) {
+        if (event.getUniverse() != null) {
+            ServerUtilitiesLeaderboards.loadLeaderboards();
+        }
+        return true;
     }
 
     public void handleClientMessage(MessageToClient message) {}

--- a/src/main/java/serverutils/ServerUtilitiesCommon.java
+++ b/src/main/java/serverutils/ServerUtilitiesCommon.java
@@ -44,7 +44,6 @@ import serverutils.aurora.Aurora;
 import serverutils.aurora.AuroraConfig;
 import serverutils.aurora.mc.AuroraMinecraftHandler;
 import serverutils.command.ServerUtilitiesCommands;
-import serverutils.data.Leaderboard;
 import serverutils.data.NodeEntry;
 import serverutils.data.ServerUtilitiesLoadedChunkManager;
 import serverutils.data.ServerUtilitiesUniverseData;

--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -273,6 +273,9 @@ public class ServerUtilitiesConfig {
 
         @Config.DefaultBoolean(true)
         public boolean dump_permissions;
+
+        @Config.DefaultBoolean(true)
+        public boolean dump_stats;
     }
 
     public static class Backups {

--- a/src/main/java/serverutils/ServerUtilitiesLeaderboards.java
+++ b/src/main/java/serverutils/ServerUtilitiesLeaderboards.java
@@ -197,8 +197,17 @@ public final class ServerUtilitiesLeaderboards {
 
     private static IChatComponent getSafeName(StatBase stat) {
         IChatComponent component = stat.statName;
-        if (component instanceof ChatComponentTranslation translation && translation.getFormatArgs().length != 0) {
-            return new ChatComponentText(stat.statId);
+        String id = stat.statId;
+        if (component instanceof ChatComponentTranslation translation && translation.getFormatArgs().length > 0) {
+            if (translation.getFormatArgs()[0] instanceof ChatComponentTranslation arg) {
+                if (id.startsWith("stat.entityKilledBy")) {
+                    return new ChatComponentTranslation("serverutilities.stat.killed_by", arg.getUnformattedText());
+                } else if (id.startsWith("stat.killEntity")) {
+                    return new ChatComponentTranslation(
+                            "serverutilities.stat.entities_killed",
+                            arg.getUnformattedText());
+                }
+            }
         }
         return component;
     }

--- a/src/main/java/serverutils/ServerUtilitiesLeaderboards.java
+++ b/src/main/java/serverutils/ServerUtilitiesLeaderboards.java
@@ -2,6 +2,7 @@ package serverutils;
 
 import java.io.File;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.IntFunction;
 
@@ -9,7 +10,6 @@ import net.minecraft.stats.StatBase;
 import net.minecraft.stats.StatList;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.util.ChatComponentTranslationFormatException;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
 import net.minecraft.util.ResourceLocation;
@@ -18,6 +18,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import serverutils.data.Leaderboard;
+import serverutils.events.LeaderboardRegistryEvent;
 import serverutils.lib.data.ForgePlayer;
 import serverutils.lib.io.DataReader;
 import serverutils.lib.math.Ticks;
@@ -27,6 +28,7 @@ import serverutils.lib.util.permission.PermissionAPI;
 
 public final class ServerUtilitiesLeaderboards {
 
+    public static final Map<ResourceLocation, Leaderboard> LEADERBOARDS = new HashMap<>();
     private static final File STAT_LEADERBOARD_FILE = new File(
             ServerUtilities.SERVER_FOLDER + "stat_leaderboards.json");
     private static final String[] DEFAULT_STAT_LEADERBOARDS = { StatList.deathsStat.statId,
@@ -34,6 +36,7 @@ public final class ServerUtilitiesLeaderboards {
             StatList.jumpStat.statId };
 
     static void loadLeaderboards() {
+        LEADERBOARDS.clear();
         registerLeaderboard(
                 new Leaderboard(
                         new ResourceLocation(ServerUtilities.MOD_ID, "deaths_per_hour"),
@@ -76,6 +79,7 @@ public final class ServerUtilitiesLeaderboards {
                         Comparator.comparingLong(ServerUtilitiesLeaderboards::getRelativeLastSeen),
                         player -> player.getLastTimeSeen() != 0L));
         loadFromFile();
+        new LeaderboardRegistryEvent(ServerUtilitiesLeaderboards::registerLeaderboard).post();
     }
 
     private static int getActivePlayTime(ForgePlayer player) {
@@ -193,18 +197,14 @@ public final class ServerUtilitiesLeaderboards {
 
     private static IChatComponent getSafeName(StatBase stat) {
         IChatComponent component = stat.statName;
-        if (component instanceof ChatComponentTranslation translation) {
-            try {
-                translation.getUnformattedText();
-            } catch (ChatComponentTranslationFormatException e) {
-                return new ChatComponentText(stat.statId);
-            }
+        if (component instanceof ChatComponentTranslation translation && translation.getFormatArgs().length != 0) {
+            return new ChatComponentText(stat.statId);
         }
         return component;
     }
 
     public static void registerLeaderboard(Leaderboard leaderboard) {
-        ServerUtilitiesCommon.LEADERBOARDS.put(leaderboard.id, leaderboard);
+        LEADERBOARDS.put(leaderboard.id, leaderboard);
         PermissionAPI.registerNode(
                 ServerUtilitiesPermissions.getLeaderboardNode(leaderboard),
                 DefaultPermissionLevel.ALL,

--- a/src/main/java/serverutils/ServerUtilitiesLeaderboards.java
+++ b/src/main/java/serverutils/ServerUtilitiesLeaderboards.java
@@ -1,61 +1,40 @@
 package serverutils;
 
+import java.io.File;
 import java.util.Comparator;
+import java.util.Map;
+import java.util.function.IntFunction;
 
+import net.minecraft.stats.StatBase;
 import net.minecraft.stats.StatList;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.ChatComponentTranslationFormatException;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
 import net.minecraft.util.ResourceLocation;
 
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 import serverutils.data.Leaderboard;
-import serverutils.events.LeaderboardRegistryEvent;
 import serverutils.lib.data.ForgePlayer;
+import serverutils.lib.io.DataReader;
 import serverutils.lib.math.Ticks;
+import serverutils.lib.util.JsonUtils;
+import serverutils.lib.util.permission.DefaultPermissionLevel;
+import serverutils.lib.util.permission.PermissionAPI;
 
 public final class ServerUtilitiesLeaderboards {
 
-    private ServerUtilitiesLeaderboards() {}
+    private static final File STAT_LEADERBOARD_FILE = new File(
+            ServerUtilities.SERVER_FOLDER + "stat_leaderboards.json");
+    private static final String[] DEFAULT_STAT_LEADERBOARDS = { StatList.deathsStat.statId,
+            StatList.mobKillsStat.statId, StatList.minutesPlayedStat.statId, ServerUtilitiesStats.AFK_TIME.statId,
+            StatList.jumpStat.statId };
 
-    public static final ServerUtilitiesLeaderboards INST = new ServerUtilitiesLeaderboards();
-
-    @SubscribeEvent
-    @SuppressWarnings("unused") // used by reflection
-    public void registerLeaderboards(LeaderboardRegistryEvent event) {
-        event.register(
-                new Leaderboard.FromStat(
-                        new ResourceLocation(ServerUtilities.MOD_ID, "deaths"),
-                        StatList.deathsStat,
-                        false,
-                        Leaderboard.FromStat.DEFAULT));
-        event.register(
-                new Leaderboard.FromStat(
-                        new ResourceLocation(ServerUtilities.MOD_ID, "mob_kills"),
-                        StatList.mobKillsStat,
-                        false,
-                        Leaderboard.FromStat.DEFAULT));
-        event.register(
-                new Leaderboard.FromStat(
-                        new ResourceLocation(ServerUtilities.MOD_ID, "time_played"),
-                        StatList.minutesPlayedStat,
-                        false,
-                        Leaderboard.FromStat.TIME));
-        event.register(
-                new Leaderboard.FromStat(
-                        new ResourceLocation(ServerUtilities.MOD_ID, "time_afk"),
-                        ServerUtilitiesStats.AFK_TIME,
-                        false,
-                        Leaderboard.FromStat.TIME));
-        event.register(
-                new Leaderboard.FromStat(
-                        new ResourceLocation(ServerUtilities.MOD_ID, "jumps"),
-                        StatList.jumpStat,
-                        false,
-                        Leaderboard.FromStat.DEFAULT));
-
-        event.register(
+    static void loadLeaderboards() {
+        registerLeaderboard(
                 new Leaderboard(
                         new ResourceLocation(ServerUtilities.MOD_ID, "deaths_per_hour"),
                         new ChatComponentTranslation("serverutilities.stat.dph"),
@@ -65,22 +44,21 @@ public final class ServerUtilitiesLeaderboards {
                         },
                         Comparator.comparingDouble(ServerUtilitiesLeaderboards::getDPH).reversed(),
                         player -> getDPH(player) >= 0D));
-
-        event.register(
+        registerLeaderboard(
                 new Leaderboard(
                         new ResourceLocation(ServerUtilities.MOD_ID, "time_active"),
                         new ChatComponentTranslation("serverutilities.stat.time_active"),
                         player -> Leaderboard.FromStat.TIME.apply(getActivePlayTime(player)),
                         Comparator.comparingLong(ServerUtilitiesLeaderboards::getActivePlayTime).reversed(),
                         player -> getActivePlayTime(player) != 0));
-        event.register(
+        registerLeaderboard(
                 new Leaderboard(
                         new ResourceLocation(ServerUtilities.MOD_ID, "time_afk_percent"),
                         new ChatComponentTranslation("serverutilities.stat.time_afk_percent"),
                         player -> Leaderboard.FromStat.PERCENTAGE.apply(getAfkTimeFraction(player)),
                         Comparator.comparingDouble(ServerUtilitiesLeaderboards::getAfkTimeFraction).reversed(),
                         player -> getAfkTimeFraction(player) != 0));
-        event.register(
+        registerLeaderboard(
                 new Leaderboard(
                         new ResourceLocation(ServerUtilities.MOD_ID, "last_seen"),
                         new ChatComponentTranslation("serverutilities.stat.last_seen"),
@@ -97,6 +75,7 @@ public final class ServerUtilitiesLeaderboards {
                         },
                         Comparator.comparingLong(ServerUtilitiesLeaderboards::getRelativeLastSeen),
                         player -> player.getLastTimeSeen() != 0L));
+        loadFromFile();
     }
 
     private static int getActivePlayTime(ForgePlayer player) {
@@ -131,5 +110,104 @@ public final class ServerUtilitiesLeaderboards {
         }
 
         return -1D;
+    }
+
+    private static JsonElement getAndSaveDefaults() {
+        JsonObject obj = new JsonObject();
+        for (String id : DEFAULT_STAT_LEADERBOARDS) {
+            JsonObject obj1 = new JsonObject();
+            obj1.addProperty("name", "");
+            obj1.addProperty("reverse", false);
+            obj.add(id, obj1);
+        }
+
+        JsonObject example = new JsonObject();
+        example.addProperty("name", "The name that appears in the gui, leave empty/remove for default");
+        example.addProperty(
+                "reverse",
+                "(true || false) whether lower numbers should appear highest in the leaderboard");
+        obj.add("example.Stat || Full list of usable stats can be dumped with /dump_stats", example);
+        JsonUtils.toJsonSafe(STAT_LEADERBOARD_FILE, obj);
+        return obj;
+    }
+
+    private static void loadFromFile() {
+        JsonElement element;
+        if (!STAT_LEADERBOARD_FILE.exists()) {
+            element = getAndSaveDefaults();
+        } else {
+            element = DataReader.get(STAT_LEADERBOARD_FILE).safeJson();
+        }
+
+        if (JsonUtils.isNull(element)) return;
+
+        if (element.isJsonObject()) {
+            for (Map.Entry<String, JsonElement> entry : element.getAsJsonObject().entrySet()) {
+                String key = entry.getKey();
+                if (key.startsWith("example")) continue;
+
+                StatBase stat = StatList.func_151177_a(key);
+                if (stat == null) {
+                    ServerUtilities.LOGGER.warn("Couldn't find stat with id {}, skipping", key);
+                    continue;
+                }
+
+                JsonElement value = entry.getValue();
+                if (value.isJsonObject()) {
+                    JsonObject obj = value.getAsJsonObject();
+
+                    IChatComponent name;
+                    JsonElement nameElem = obj.getAsJsonPrimitive("name");
+                    if (nameElem != null && !nameElem.getAsString().isEmpty()) {
+                        name = new ChatComponentText(nameElem.getAsString());
+                    } else {
+                        name = getSafeName(stat);
+                    }
+
+                    boolean reverse = false;
+                    JsonElement reverseElem = obj.getAsJsonPrimitive("reverse");
+                    if (reverseElem != null && reverseElem.getAsBoolean()) {
+                        reverse = true;
+                    }
+
+                    registerLeaderboard(
+                            new Leaderboard.FromStat(
+                                    new ResourceLocation(ServerUtilities.MOD_ID, key),
+                                    name,
+                                    stat,
+                                    reverse,
+                                    getStatIntFunction(stat)));
+
+                }
+            }
+        }
+    }
+
+    private static IntFunction<IChatComponent> getStatIntFunction(StatBase stat) {
+        if (stat.type.equals(StatBase.timeStatType)) {
+            return Leaderboard.FromStat.TIME;
+        }
+
+        return Leaderboard.FromStat.DEFAULT;
+    }
+
+    private static IChatComponent getSafeName(StatBase stat) {
+        IChatComponent component = stat.statName;
+        if (component instanceof ChatComponentTranslation translation) {
+            try {
+                translation.getUnformattedText();
+            } catch (ChatComponentTranslationFormatException e) {
+                return new ChatComponentText(stat.statId);
+            }
+        }
+        return component;
+    }
+
+    public static void registerLeaderboard(Leaderboard leaderboard) {
+        ServerUtilitiesCommon.LEADERBOARDS.put(leaderboard.id, leaderboard);
+        PermissionAPI.registerNode(
+                ServerUtilitiesPermissions.getLeaderboardNode(leaderboard),
+                DefaultPermissionLevel.ALL,
+                "");
     }
 }

--- a/src/main/java/serverutils/ServerUtilitiesPermissions.java
+++ b/src/main/java/serverutils/ServerUtilitiesPermissions.java
@@ -264,10 +264,6 @@ public class ServerUtilitiesPermissions {
                     CLAIMS_ITEM_BLACKLIST.contains(item) ? DefaultPermissionLevel.OP : DefaultPermissionLevel.ALL,
                     "");
         }
-
-        for (Leaderboard leaderboard : ServerUtilitiesCommon.LEADERBOARDS.values()) {
-            PermissionAPI.registerNode(getLeaderboardNode(leaderboard), DefaultPermissionLevel.ALL, "");
-        }
     }
 
     @SubscribeEvent

--- a/src/main/java/serverutils/ServerUtilitiesPermissions.java
+++ b/src/main/java/serverutils/ServerUtilitiesPermissions.java
@@ -1,7 +1,10 @@
 package serverutils;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -16,6 +19,7 @@ import net.minecraft.item.ItemBucket;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.registry.GameData;
 import serverutils.data.Leaderboard;
+import serverutils.data.NodeEntry;
 import serverutils.events.CustomPermissionPrefixesRegistryEvent;
 import serverutils.events.RegisterRankConfigEvent;
 import serverutils.events.RegisterRankConfigHandlerEvent;
@@ -97,7 +101,7 @@ public class ServerUtilitiesPermissions {
     public static final String INFINITE_BACK_USAGE = "serverutilities.back.infinite";
     public static final String CRASH_REPORTS_VIEW = "admin_panel.serverutilities.crash_reports.view";
     public static final String CRASH_REPORTS_DELETE = "admin_panel.serverutilities.crash_reports.delete";
-    private static final String LEADERBOARD_PREFIX = "serverutilities.leaderboard.";
+    public static final String LEADERBOARD_PREFIX = "serverutilities.leaderboard.";
     public static final String EDIT_WORLD_GAMERULES = "admin_panel.serverutilities.edit_world.gamerules";
     public static final String RANK_EDIT = "serverutilities.admin_panel.ranks.view";
 
@@ -366,7 +370,19 @@ public class ServerUtilitiesPermissions {
         return PermissionAPI.hasPermission(player, CLAIMS_ITEM_PREFIX + '.' + formatId(block));
     }
 
+    public static Collection<NodeEntry> getPrefixes() {
+        return ServerUtilitiesCommon.CUSTOM_PERM_PREFIX_REGISTRY;
+    }
+
+    public static Collection<NodeEntry> getPrefixesExcluding(String... toExclude) {
+        return ServerUtilitiesCommon.CUSTOM_PERM_PREFIX_REGISTRY.stream().filter(
+                prefix -> toExclude.length == 0 || Arrays.stream(toExclude).noneMatch(prefix.getNode()::startsWith))
+                .collect(Collectors.toSet());
+    }
+
     public static String getLeaderboardNode(Leaderboard leaderboard) {
-        return LEADERBOARD_PREFIX + leaderboard.id.getResourceDomain() + "." + leaderboard.id.getResourcePath();
+        String domain = leaderboard.id.getResourceDomain();
+        String id = (domain.equals(ServerUtilities.MOD_ID) ? "" : domain + ".") + leaderboard.id.getResourcePath();
+        return LEADERBOARD_PREFIX + id;
     }
 }

--- a/src/main/java/serverutils/command/CmdDumpStats.java
+++ b/src/main/java/serverutils/command/CmdDumpStats.java
@@ -1,0 +1,117 @@
+package serverutils.command;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.EntityList;
+import net.minecraft.stats.StatBase;
+import net.minecraft.stats.StatList;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.ChatComponentTranslationFormatException;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.util.StatCollector;
+
+import serverutils.ServerUtilities;
+import serverutils.lib.command.CmdBase;
+import serverutils.lib.util.FileUtils;
+import serverutils.lib.util.StringUtils;
+
+public class CmdDumpStats extends CmdBase {
+
+    private static final File statDumpFile = new File(ServerUtilities.SERVER_FOLDER + "stat_dump.txt");
+
+    public CmdDumpStats() {
+        super("dump_stats", Level.OP_OR_SP);
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        FileUtils.delete(statDumpFile);
+        List<String> output = new ArrayList<>();
+        List<StatBase> stats = StatList.allStats;
+
+        List<String> achievementStats = new ArrayList<>();
+        List<String> craftStats = new ArrayList<>();
+        List<String> useStats = new ArrayList<>();
+        List<String> itemsBrokeStats = new ArrayList<>();
+        List<String> blocksMinedStats = new ArrayList<>();
+        List<String> miscStats = new ArrayList<>();
+        for (StatBase stat : stats) {
+            String statId = stat.statId;
+
+            // These two have to be added differently later on
+            if (statId.startsWith("stat.entityKilledBy") || statId.startsWith("stat.killEntity")) {
+                continue;
+            }
+
+            String statStr = getStatString(stat);
+            if (statId.contains("achievement.")) {
+                achievementStats.add(statStr);
+                continue;
+            } else if (statId.contains("craftItem.")) {
+                craftStats.add(statStr);
+                continue;
+            } else if (statId.contains("useItem.")) {
+                useStats.add(statStr);
+                continue;
+            } else if (statId.contains("breakItem.")) {
+                itemsBrokeStats.add(statStr);
+                continue;
+            } else if (statId.contains("mineBlock.")) {
+                blocksMinedStats.add(statStr);
+                continue;
+            }
+
+            miscStats.add(statStr);
+        }
+
+        List<String> killStats = new ArrayList<>();
+        for (EntityList.EntityEggInfo eggInfo : EntityList.entityEggs.values()) {
+            String killedById = eggInfo.field_151513_e == null ? "null" : eggInfo.field_151513_e.statId;
+            String killsId = eggInfo.field_151512_d == null ? "null" : eggInfo.field_151512_d.statId;
+            String entityArg = StatCollector
+                    .translateToLocal("entity." + EntityList.getStringFromID(eggInfo.spawnedID) + ".name");
+            killStats.add(
+                    killedById + " || " + StatCollector.translateToLocalFormatted("stat.entityKilledBy", entityArg, 0));
+            killStats.add(killsId + " || " + StatCollector.translateToLocalFormatted("stat.entityKills", 0, entityArg));
+        }
+
+        addSection(output, "Misc. Stats", miscStats);
+        addSection(output, "Achievement Stats", achievementStats);
+        addSection(output, "Craft Stats", craftStats);
+        addSection(output, "Use Stats", useStats);
+        addSection(output, "Items Broke Stats", itemsBrokeStats);
+        addSection(output, "Blocks Mined Stats", blocksMinedStats);
+        addSection(output, "Kill Stats", killStats);
+
+        FileUtils.saveSafe(statDumpFile, output);
+        sender.addChatMessage(
+                new ChatComponentText("Dumped " + stats.size() + " stats to file " + statDumpFile.getPath()));
+    }
+
+    private String getStatString(StatBase stat) {
+        String base = stat.statId + " || ";
+        IChatComponent statName = stat.statName;
+        if (statName instanceof ChatComponentTranslation translation) {
+            try {
+                return base + translation.getUnformattedText();
+            } catch (ChatComponentTranslationFormatException e) {
+                return base + stat.statId;
+            }
+        }
+
+        return base + statName.getUnformattedText();
+    }
+
+    private void addSection(List<String> output, String title, List<String> stats) {
+        output.add("--------------------");
+        output.add(title);
+        output.add("--------------------");
+        stats.sort(StringUtils.IGNORE_CASE_COMPARATOR);
+        output.addAll(stats);
+    }
+
+}

--- a/src/main/java/serverutils/command/CmdLeaderboard.java
+++ b/src/main/java/serverutils/command/CmdLeaderboard.java
@@ -14,7 +14,7 @@ import net.minecraft.util.IChatComponent;
 import net.minecraft.util.ResourceLocation;
 
 import serverutils.ServerUtilities;
-import serverutils.ServerUtilitiesCommon;
+import serverutils.ServerUtilitiesLeaderboards;
 import serverutils.data.Leaderboard;
 import serverutils.lib.command.CmdBase;
 import serverutils.lib.data.ForgePlayer;
@@ -30,7 +30,7 @@ public class CmdLeaderboard extends CmdBase {
     @Override
     public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
         if (args.length == 1) {
-            return matchFromIterable(args, ServerUtilitiesCommon.LEADERBOARDS.keySet());
+            return matchFromIterable(args, ServerUtilitiesLeaderboards.LEADERBOARDS.keySet());
         }
 
         return super.addTabCompletionOptions(sender, args);
@@ -46,7 +46,7 @@ public class CmdLeaderboard extends CmdBase {
                             StringUtils.color(ServerUtilities.lang(sender, "click_here"), EnumChatFormatting.GOLD)));
             boolean first = true;
 
-            for (Leaderboard leaderboard : ServerUtilitiesCommon.LEADERBOARDS.values()) {
+            for (Leaderboard leaderboard : ServerUtilitiesLeaderboards.LEADERBOARDS.values()) {
                 if (first) {
                     first = false;
                 } else {
@@ -61,8 +61,8 @@ public class CmdLeaderboard extends CmdBase {
             }
 
             sender.addChatMessage(component);
-        } else if (ServerUtilitiesCommon.LEADERBOARDS.get(new ResourceLocation(args[0])) != null) {
-            Leaderboard leaderboard = ServerUtilitiesCommon.LEADERBOARDS.get(new ResourceLocation(args[0]));
+        } else if (ServerUtilitiesLeaderboards.LEADERBOARDS.get(new ResourceLocation(args[0])) != null) {
+            Leaderboard leaderboard = ServerUtilitiesLeaderboards.LEADERBOARDS.get(new ResourceLocation(args[0]));
             sender.addChatMessage(leaderboard.getTitle().createCopy().appendText(":"));
 
             ForgePlayer p0 = sender instanceof EntityPlayerMP ? Universe.get().getPlayer(sender) : null;

--- a/src/main/java/serverutils/command/ServerUtilitiesCommands.java
+++ b/src/main/java/serverutils/command/ServerUtilitiesCommands.java
@@ -140,5 +140,8 @@ public class ServerUtilitiesCommands {
         if (ServerUtilitiesConfig.debugging.special_commands) {
             event.registerServerCommand(new CmdAddFakePlayer());
         }
+        if (ServerUtilitiesConfig.commands.dump_stats) {
+            event.registerServerCommand(new CmdDumpStats());
+        }
     }
 }

--- a/src/main/java/serverutils/net/MessageLeaderboard.java
+++ b/src/main/java/serverutils/net/MessageLeaderboard.java
@@ -3,7 +3,7 @@ package serverutils.net;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ResourceLocation;
 
-import serverutils.ServerUtilitiesCommon;
+import serverutils.ServerUtilitiesLeaderboards;
 import serverutils.ServerUtilitiesPermissions;
 import serverutils.data.Leaderboard;
 import serverutils.lib.io.DataIn;
@@ -39,7 +39,7 @@ public class MessageLeaderboard extends MessageToServer {
 
     @Override
     public void onMessage(EntityPlayerMP player) {
-        Leaderboard leaderboard = ServerUtilitiesCommon.LEADERBOARDS.get(id);
+        Leaderboard leaderboard = ServerUtilitiesLeaderboards.LEADERBOARDS.get(id);
 
         if (leaderboard != null
                 && PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.getLeaderboardNode(leaderboard))) {

--- a/src/main/java/serverutils/net/MessageLeaderboardList.java
+++ b/src/main/java/serverutils/net/MessageLeaderboardList.java
@@ -7,7 +7,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.IChatComponent;
 import net.minecraft.util.ResourceLocation;
 
-import serverutils.ServerUtilitiesCommon;
+import serverutils.ServerUtilitiesLeaderboards;
 import serverutils.ServerUtilitiesPermissions;
 import serverutils.data.Leaderboard;
 import serverutils.lib.net.MessageToServer;
@@ -25,7 +25,7 @@ public class MessageLeaderboardList extends MessageToServer {
     public void onMessage(EntityPlayerMP player) {
         Map<ResourceLocation, IChatComponent> map = new LinkedHashMap<>();
 
-        for (Leaderboard leaderboard : ServerUtilitiesCommon.LEADERBOARDS.values()) {
+        for (Leaderboard leaderboard : ServerUtilitiesLeaderboards.LEADERBOARDS.values()) {
             if (PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.getLeaderboardNode(leaderboard))) {
                 map.put(leaderboard.id, leaderboard.getTitle());
             }

--- a/src/main/java/serverutils/net/MessageRanks.java
+++ b/src/main/java/serverutils/net/MessageRanks.java
@@ -1,5 +1,7 @@
 package serverutils.net;
 
+import static serverutils.ServerUtilitiesPermissions.LEADERBOARD_PREFIX;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -13,8 +15,8 @@ import net.minecraft.util.IChatComponent;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import serverutils.ServerUtilitiesCommon;
 import serverutils.ServerUtilitiesConfig;
+import serverutils.ServerUtilitiesPermissions;
 import serverutils.client.gui.ranks.GuiRanks;
 import serverutils.client.gui.ranks.RankInst;
 import serverutils.data.NodeEntry;
@@ -112,13 +114,13 @@ public class MessageRanks extends MessageToClient {
                         .setDisplayName(new ChatComponentTranslation(info.node));
             }
 
-            for (String s : PermissionAPI.getPermissionHandler().getRegisteredNodes()) {
-                DefaultPermissionLevel level = DefaultPermissionHandler.INSTANCE.getDefaultPermissionLevel(s);
-                String desc = PermissionAPI.getPermissionHandler().getNodeDescription(s);
+            for (String node : PermissionAPI.getPermissionHandler().getRegisteredNodes()) {
+                DefaultPermissionLevel level = DefaultPermissionHandler.INSTANCE.getDefaultPermissionLevel(node);
+                String desc = PermissionAPI.getPermissionHandler().getNodeDescription(node);
                 boolean printNode = true;
 
-                for (NodeEntry cprefix : ServerUtilitiesCommon.CUSTOM_PERM_PREFIX_REGISTRY) {
-                    if (s.startsWith(cprefix.getNode())) {
+                for (NodeEntry cprefix : ServerUtilitiesPermissions.getPrefixesExcluding(LEADERBOARD_PREFIX)) {
+                    if (node.startsWith(cprefix.getNode())) {
                         if (cprefix.level != null && level == cprefix.level && desc.isEmpty()) {
                             printNode = false;
                         }
@@ -128,8 +130,8 @@ public class MessageRanks extends MessageToClient {
 
                 if (printNode) {
                     ConfigValue val = new ConfigBoolean(level == DefaultPermissionLevel.ALL);
-                    allPermissions.add(s, val, val, StringUtils.FLAG_ID_PERIOD_DEFAULTS)
-                            .setDisplayName(new ChatComponentTranslation(s));
+                    allPermissions.add(node, val, val, StringUtils.FLAG_ID_PERIOD_DEFAULTS)
+                            .setDisplayName(new ChatComponentTranslation(node));
                 }
             }
         }

--- a/src/main/resources/META-INF/serverutil_at.cfg
+++ b/src/main/resources/META-INF/serverutil_at.cfg
@@ -22,3 +22,5 @@ public net.minecraft.entity.Entity field_96093_i # entityUniqueID
 public net.minecraft.client.gui.inventory.GuiContainer field_147003_i #guiLeft
 public net.minecraft.client.gui.inventory.GuiContainer field_147009_r #guitop
 public net.minecraft.tileentity.TileEntity field_145853_j # classToNameMap
+public net.minecraft.stats.StatBase field_75978_a # statName
+public net.minecraft.stats.StatBase field_75976_b # type

--- a/src/main/resources/assets/serverutilities/lang/en_US.lang
+++ b/src/main/resources/assets/serverutilities/lang/en_US.lang
@@ -27,6 +27,8 @@ serverutilities.stat.time_afk_percent=Percentage of time spent AFK
 serverutilities.stat.time_active=Time actively playing (not AFK)
 serverutilities.stat.dph=Deaths Per Hour
 serverutilities.stat.last_seen=Last Seen
+serverutilities.stat.killed_by=Deaths by %s
+serverutilities.stat.entities_killed=%ss killed
 
 wip=Work In Progress!
 deprecated=This method is deprecated, please use %s


### PR DESCRIPTION
Makes it possible for server owners to easily add leaderboards for any registered stat, so if you ever wanted a leaderboard for most iron shovels broken, distance traveled by minecart, amount of fish caught etc. you can now :) (this also includes stats registered by other mods)

Moves all of the existing stat leaderboards (any leaderboard that only needs a minecraft stat to function) to the new leaderboards.json file in the `/serverutilities/server` folder.
It's super easy to add new ones as you only really need to copy one of the existing ones and switch the stat id to the one you want, the name of the leaderboard as well as the ordering of the entries in the leaderboard can also be changed in the file if desired.
A full list of registered stat id's along with as good a description as we can get can be dumped to txt file using /dump_stats.

Also stops piggybacking of our own event to register the leaderboards. The event continues to exist for other mods to use.

Closes https://github.com/GTNewHorizons/ServerUtilities/issues/111