### PR TITLE
Fix afk time always ticking

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -167,7 +167,7 @@ public class ServerUtilitiesConfig {
         public boolean enabled;
 
         @Config.Comment("Enables afk timer in singleplayer.")
-        @Config.DefaultBoolean(false)
+        @Config.DefaultBoolean(true)
         public boolean enabled_singleplayer;
 
         @Config.Comment("After how much time it will display notification to all players.")
@@ -175,7 +175,7 @@ public class ServerUtilitiesConfig {
         public String notification_timer;
 
         @Config.Ignore
-        private long notificationTimer;
+        private long notificationTimer = -1L;
 
         public boolean isEnabled(MinecraftServer server) {
             return enabled && (enabled_singleplayer || !server.isSinglePlayer());


### PR DESCRIPTION
https://discord.com/channels/181078474394566657/522098956491030558/1282468723709706383

Oops, looks like I missed something during the config migration which caused the afk timer to never get set :)

![su_afk](https://github.com/user-attachments/assets/ce8f3da8-bb55-4ef5-9dcc-fa1abc5a6eb9)
:trollface: 
