### PR TITLE
Fix some tasks queuing notifications while disabled

### DIFF
--- a/src/main/java/serverutils/lib/data/Universe.java
+++ b/src/main/java/serverutils/lib/data/Universe.java
@@ -240,6 +240,7 @@ public class Universe {
     public void scheduleTask(Task task, boolean condition) {
         if (!condition) return;
         if (task.getNextTime() <= -1) return;
+        task.queueNotifications(this);
         taskQueue.add(task);
     }
 

--- a/src/main/java/serverutils/task/Task.java
+++ b/src/main/java/serverutils/task/Task.java
@@ -28,8 +28,6 @@ public abstract class Task {
         this.interval = getTimeType() == TimeType.MILLIS ? ticks.millis() : ticks.ticks();
         this.nextTime = whenToRun + interval;
         this.repeatable = repeatable;
-
-        queueNotifications(Universe.get());
     }
 
     public abstract void execute(Universe universe);
@@ -51,7 +49,7 @@ public abstract class Task {
         queueNotifications(Universe.get());
     }
 
-    private void queueNotifications(Universe universe) {
+    public void queueNotifications(Universe universe) {
         List<NotifyTask> notifications = getNotifications();
         if (notifications == null || notifications.isEmpty()) return;
         getNotifications().forEach(universe::scheduleTask);


### PR DESCRIPTION
The cleanup task was queuing them unconditionally at server start, they would only ever be sent once though.