### PR TITLE
Fix crash with commands that doesn't extend CommandBase

### DIFF
--- a/src/main/java/serverutils/command/CmdDumpPermissions.java
+++ b/src/main/java/serverutils/command/CmdDumpPermissions.java
@@ -150,8 +150,8 @@ public class CmdDumpPermissions extends CmdBase {
         commandList.add(Arrays.asList(EMPTY_ROW));
 
         for (ICommand command : CommandUtils.getAllCommands(sender)) {
-            ICommandWithPermission commands = (ICommandWithPermission) command;
-            String node = commands.serverutilities$getPermissionNode();
+            ICommandWithPermission cmd = (ICommandWithPermission) command;
+            String node = cmd.serverutilities$getPermissionNode();
             DefaultPermissionLevel defaultPermissionLevel = DefaultPermissionHandler.INSTANCE
                     .getDefaultPermissionLevel(node);
             IChatComponent usage = CommandUtils.getTranslatedUsage(command, sender);
@@ -159,7 +159,7 @@ public class CmdDumpPermissions extends CmdBase {
             commandList.add(
                     Arrays.asList(
                             node,
-                            "/" + commands.getCommandName(),
+                            "/" + command.getCommandName(),
                             defaultPermissionLevel.name(),
                             usage.getUnformattedText()));
         }

--- a/src/main/java/serverutils/mixin/Mixins.java
+++ b/src/main/java/serverutils/mixin/Mixins.java
@@ -17,8 +17,10 @@ import serverutils.ServerUtilities;
 public enum Mixins {
 
     COMMAND_PERMISSIONS(new Builder("Command Permissions").addTargetedMod(VANILLA).setSide(Side.BOTH)
-            .setPhase(Phase.EARLY).setApplyIf(() -> ranks.enabled && ranks.command_permissions)
-            .addMixinClasses("minecraft.MixinCommandBase", "minecraft.MixinCommandHandler"));
+            .setPhase(Phase.EARLY).setApplyIf(() -> ranks.enabled && ranks.command_permissions).addMixinClasses(
+                    "minecraft.MixinCommandBase",
+                    "minecraft.MixinCommandHandler",
+                    "minecraft.MixinICommand")),;
 
     private final List<String> mixinClasses;
     private final Supplier<Boolean> applyIf;

--- a/src/main/java/serverutils/net/MessageRanks.java
+++ b/src/main/java/serverutils/net/MessageRanks.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
+import net.minecraft.command.ICommand;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
@@ -137,8 +138,8 @@ public class MessageRanks extends MessageToClient {
                         EnumChatFormatting.BLUE + "[" + command.serverutilities$getModName() + "]\n");
                 ConfigBoolean val = new ConfigBoolean(level == DefaultPermissionLevel.ALL);
                 commandPermissions.add(node, val, val, StringUtils.FLAG_ID_PERIOD_DEFAULTS)
-                        .setDisplayName(new ChatComponentTranslation(node))
-                        .setInfo(name.appendSibling(CommandUtils.getTranslatedUsage(command, p.getPlayer())));
+                        .setDisplayName(new ChatComponentTranslation(node)).setInfo(
+                                name.appendSibling(CommandUtils.getTranslatedUsage((ICommand) command, p.getPlayer())));
             }
         }
     }

--- a/src/main/java/serverutils/ranks/ICommandWithPermission.java
+++ b/src/main/java/serverutils/ranks/ICommandWithPermission.java
@@ -1,10 +1,15 @@
 package serverutils.ranks;
 
-import net.minecraft.command.ICommand;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.jetbrains.annotations.NotNull;
 
-public interface ICommandWithPermission extends ICommand {
+public interface ICommandWithPermission {
+
+    Map<String, String> commandOwners = new HashMap<>();
+
+    Map<String, String> commandPermissions = new HashMap<>();
 
     String serverutilities$getPermissionNode();
 

--- a/src/mixins/java/serverutils/mixins/early/minecraft/MixinCommandHandler.java
+++ b/src/mixins/java/serverutils/mixins/early/minecraft/MixinCommandHandler.java
@@ -58,13 +58,13 @@ public abstract class MixinCommandHandler {
         String node = (container == null ? Rank.NODE_COMMAND : (Rank.NODE_COMMAND + '.' + container.getModId())) + "."
                 + command.getCommandName();
         ICommandWithPermission cmd = (ICommandWithPermission) command;
-        cmd.serverutilities$setPermissionNode(node);
+        cmd.serverutilities$setPermissionNode(node.toLowerCase());
         cmd.serverutilities$setModName(container == null ? "Minecraft" : container.getName());
         serverUtilities$registerPermissions(cmd);
     }
 
     @Unique
-    private DefaultPermissionLevel serverUtilities$getDefaultLevel(ICommand command) {
+    private DefaultPermissionLevel serverUtilities$getDefaultLevel(ICommandWithPermission command) {
         if (command instanceof CommandBase cmdBase) {
             return cmdBase.getRequiredPermissionLevel() > 0 ? DefaultPermissionLevel.OP : DefaultPermissionLevel.ALL;
         }
@@ -79,7 +79,7 @@ public abstract class MixinCommandHandler {
         if (command instanceof CommandTreeBase tree) {
             for (ICommand c : tree.getSubCommands()) {
                 ICommandWithPermission child = (ICommandWithPermission) c;
-                child.serverutilities$setPermissionNode(node + '.' + child.getCommandName());
+                child.serverutilities$setPermissionNode(node.toLowerCase() + '.' + c.getCommandName());
                 child.serverutilities$setModName(command.serverutilities$getModName());
                 serverUtilities$registerPermissions(child);
             }

--- a/src/mixins/java/serverutils/mixins/early/minecraft/MixinICommand.java
+++ b/src/mixins/java/serverutils/mixins/early/minecraft/MixinICommand.java
@@ -1,0 +1,36 @@
+package serverutils.mixins.early.minecraft;
+
+import net.minecraft.command.ICommand;
+
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import serverutils.ranks.ICommandWithPermission;
+
+@Mixin(ICommand.class)
+public interface MixinICommand extends ICommandWithPermission {
+
+    @Shadow
+    String getCommandName();
+
+    @Override
+    default String serverutilities$getPermissionNode() {
+        return commandPermissions.get(getCommandName());
+    }
+
+    @Override
+    default void serverutilities$setPermissionNode(@NotNull String node) {
+        commandPermissions.put(getCommandName(), node);
+    }
+
+    @Override
+    default String serverutilities$getModName() {
+        return commandOwners.get(getCommandName());
+    }
+
+    @Override
+    default void serverutilities$setModName(@NotNull String modName) {
+        commandOwners.put(getCommandName(), modName);
+    }
+}


### PR DESCRIPTION
https://discord.com/channels/181078474394566657/522098956491030558/1298990193440985203
I forgot that non `CommandBase` commands were actually used but it should work fine for all commands now.

Tested with MT which previously caused a crash and no issues there
![mt_perm](https://github.com/user-attachments/assets/68949571-0ac7-40fc-b11f-2b400c638208)

Closes https://github.com/GTNewHorizons/ServerUtilities/issues/127