### PR TITLE
Use vanilla tooltip rendering for sidebar buttons and fix Z height

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 
 dependencies {
 
-    api("com.github.GTNewHorizons:GTNHLib:0.5.17:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.5.18:dev")
     compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.6.44-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:EnderIO:2.8.20:dev")
     compileOnly("com.github.GTNewHorizons:Navigator:1.0.15:dev")

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.27'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.28'
 }
 
 

--- a/src/main/java/serverutils/client/gui/GuiSidebar.java
+++ b/src/main/java/serverutils/client/gui/GuiSidebar.java
@@ -115,40 +115,18 @@ public class GuiSidebar extends GuiButton {
             }
         }
 
-        if (mouseOver != null) {
-            int mx1 = mx + 10;
-            int my1 = Math.max(3, my - 9);
-
-            List<String> list = new ArrayList<>();
-            list.add(StatCollector.translateToLocal(mouseOver.button.getLangKey()));
-
-            if (mouseOver.button.isDisabled()) {
-                list.add(EnumChatFormatting.RED + ClientUtils.getDisabledTip());
-            }
-
-            if (mouseOver.button.getTooltipHandler() != null) {
-                mouseOver.button.getTooltipHandler().accept(list);
-            }
-
-            int tw = 0;
-
-            for (String s : list) {
-                tw = Math.max(tw, font.getStringWidth(s));
-            }
-
-            Color4I.DARK_GRAY.draw(mx1 - 3, my1 - 2, tw + 6, 2 + list.size() * 10);
-
-            for (int i = 0; i < list.size(); i++) {
-                font.drawString(list.get(i), mx1, my1 + i * 10, 0xFFFFFFFF);
-            }
-        }
-
         GlStateManager.color(1F, 1F, 1F, 1F);
         GlStateManager.disableDepth();
         GlStateManager.popMatrix();
         zLevel = 0F;
 
         lastDrawnArea = new Rectangle(xPosition, yPosition, width, height);
+    }
+
+    public void addTooltip(List<String> textLines) {
+        if (mouseOver != null) {
+            mouseOver.addTooltip(textLines);
+        }
     }
 
     @Override
@@ -213,7 +191,7 @@ public class GuiSidebar extends GuiButton {
                         rx++;
                         addedAny = true;
                     }
-                };
+                }
 
                 if (placement != EnumPlacement.GROUPED) {
                     if (ry >= max) {
@@ -285,6 +263,18 @@ public class GuiSidebar extends GuiButton {
             buttonX = x;
             buttonY = y;
             button = b;
+        }
+
+        public void addTooltip(List<String> textLines) {
+            textLines.add(StatCollector.translateToLocal(button.getLangKey()));
+
+            if (button.isDisabled()) {
+                textLines.add(EnumChatFormatting.RED + ClientUtils.getDisabledTip());
+            }
+
+            if (button.getTooltipHandler() != null) {
+                button.getTooltipHandler().accept(textLines);
+            }
         }
     }
 }

--- a/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -60,6 +61,8 @@ public class ServerUtilitiesClientEventHandler {
     private static Temp currentNotification;
     public static boolean shouldRenderIcons = false;
     public static long shutdownTime = 0L;
+
+    private static final List<String> sidebarButtonTooltip = new ArrayList<>();
 
     public static void readSyncData(NBTTagCompound nbt) {
         shutdownTime = System.currentTimeMillis() + nbt.getLong("ShutdownTime");
@@ -279,6 +282,23 @@ public class ServerUtilitiesClientEventHandler {
                 }
                 ClientUtils.RUN_LATER.clear();
             }
+        }
+    }
+
+    /**
+     * Renders sidebar button tooltips outside of {@link GuiSidebar#drawButton} so that other screen elements don't draw
+     * over it.
+     */
+    @SubscribeEvent
+    public void onGuiScreenDraw(final GuiScreenEvent.DrawScreenEvent.Post event) {
+        if (ClientUtils.areButtonsVisible(event.gui)) {
+            event.gui.buttonList.forEach((GuiButton button) -> {
+                if (button instanceof GuiSidebar sidebar) {
+                    sidebarButtonTooltip.clear();
+                    sidebar.addTooltip(sidebarButtonTooltip);
+                    event.gui.func_146283_a(sidebarButtonTooltip, event.mouseX, event.mouseY);
+                }
+            });
         }
     }
 

--- a/src/main/resources/META-INF/serverutil_at.cfg
+++ b/src/main/resources/META-INF/serverutil_at.cfg
@@ -3,6 +3,8 @@ public net.minecraft.util.EnumChatFormatting field_96329_z # formattingCode
 public net.minecraft.command.CommandHandler field_71561_b # commandSet
 public net.minecraft.server.management.ServerConfigurationManager field_72407_n # commandsAllowedForAll
 public net.minecraft.client.gui.FontRenderer field_111274_c # unicodePageLocations
+public net.minecraft.client.gui.GuiScreen field_146292_n # buttonList
+public net.minecraft.client.gui.GuiScreen func_146283_a(Ljava/util/List;II)V
 public net.minecraft.util.ChatStyle field_150248_c # bold
 public net.minecraft.util.ChatStyle field_150245_d # italic
 public net.minecraft.util.ChatStyle field_150243_f # strikethrough


### PR DESCRIPTION
This ditches custom tooltip rendering to make things more consistent and fix things rendering over it.

Before:
![2024-10-29_14 52 13](https://github.com/user-attachments/assets/8174f2d3-ea0b-45fb-97bc-ea48ac710a5d)

After:
![2024-10-29_14 51 01](https://github.com/user-attachments/assets/635fba9b-a8f6-41df-bd04-5b5dc8acdcc0)

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17776