### PR TITLE
Make names in tab menu replaceable by display name

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -173,6 +173,10 @@ public class ServerUtilitiesConfig {
         @Config.Comment("Adds ~ to player names that have changed nickname to prevent trolling.")
         @Config.DefaultBoolean(false)
         public boolean add_nickname_tilde;
+
+        @Config.Comment("Replaces player names in the TAB screen with the names used in chat.")
+        @Config.DefaultBoolean(true)
+        public boolean replace_tab_names;
     }
 
     public static class Commands {

--- a/src/main/java/serverutils/client/gui/misc/GuiPlayerInfoWrapper.java
+++ b/src/main/java/serverutils/client/gui/misc/GuiPlayerInfoWrapper.java
@@ -1,0 +1,18 @@
+package serverutils.client.gui.misc;
+
+import net.minecraft.client.gui.GuiPlayerInfo;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class GuiPlayerInfoWrapper extends GuiPlayerInfo {
+
+    public String displayName;
+
+    public GuiPlayerInfoWrapper(GuiPlayerInfo info, String displayName) {
+        super(info.name);
+        this.responseTime = info.responseTime;
+        this.displayName = displayName;
+    }
+}

--- a/src/main/java/serverutils/command/CmdNick.java
+++ b/src/main/java/serverutils/command/CmdNick.java
@@ -5,12 +5,14 @@ import net.minecraft.command.ICommandSender;
 import net.minecraft.util.EnumChatFormatting;
 
 import serverutils.ServerUtilities;
+import serverutils.ServerUtilitiesConfig;
 import serverutils.ServerUtilitiesPermissions;
 import serverutils.data.ServerUtilitiesPlayerData;
 import serverutils.lib.command.CmdBase;
 import serverutils.lib.command.CommandUtils;
 import serverutils.lib.data.ForgePlayer;
 import serverutils.lib.util.StringUtils;
+import serverutils.net.MessageUpdateTabName;
 
 public class CmdNick extends CmdBase {
 
@@ -43,6 +45,10 @@ public class CmdNick extends CmdBase {
 
             player.getPlayer().addChatMessage(
                     ServerUtilities.lang(player.getPlayer(), "serverutilities.lang.nickname_changed", name));
+        }
+
+        if (ServerUtilitiesConfig.chat.replace_tab_names) {
+            new MessageUpdateTabName(player).sendToAll();
         }
     }
 }

--- a/src/main/java/serverutils/command/CmdNickFor.java
+++ b/src/main/java/serverutils/command/CmdNickFor.java
@@ -5,11 +5,13 @@ import net.minecraft.command.ICommandSender;
 import net.minecraft.util.EnumChatFormatting;
 
 import serverutils.ServerUtilities;
+import serverutils.ServerUtilitiesConfig;
 import serverutils.data.ServerUtilitiesPlayerData;
 import serverutils.lib.command.CmdBase;
 import serverutils.lib.command.CommandUtils;
 import serverutils.lib.data.ForgePlayer;
 import serverutils.lib.util.StringUtils;
+import serverutils.net.MessageUpdateTabName;
 
 public class CmdNickFor extends CmdBase {
 
@@ -35,6 +37,10 @@ public class CmdNickFor extends CmdBase {
             }
 
             sender.addChatMessage(ServerUtilities.lang(sender, "serverutilities.lang.nickname_changed", name));
+        }
+
+        if (ServerUtilitiesConfig.chat.replace_tab_names) {
+            new MessageUpdateTabName(player).sendToAll();
         }
     }
 }

--- a/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
@@ -48,6 +48,7 @@ import serverutils.lib.util.ServerUtils;
 import serverutils.lib.util.StringUtils;
 import serverutils.lib.util.permission.PermissionAPI;
 import serverutils.net.MessageSyncData;
+import serverutils.net.MessageUpdateTabName;
 import serverutils.task.backup.BackupTask;
 
 public class ServerUtilitiesPlayerEventHandler {
@@ -87,6 +88,10 @@ public class ServerUtilitiesPlayerEventHandler {
                 data.unDecayChunkloads();
             }
             team.refreshActivity();
+        }
+
+        if (ServerUtilitiesConfig.chat.replace_tab_names) {
+            new MessageUpdateTabName(event.getPlayer()).sendToAll();
         }
 
         BackupTask.hadPlayer = true;

--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -30,6 +30,7 @@ import serverutils.events.universe.UniverseClearCacheEvent;
 import serverutils.lib.EnumMessageLocation;
 import serverutils.lib.config.ConfigEnum;
 import serverutils.lib.config.RankConfigAPI;
+import serverutils.lib.data.ForgePlayer;
 import serverutils.lib.data.Universe;
 import serverutils.lib.util.NBTUtils;
 import serverutils.lib.util.ServerUtils;
@@ -38,6 +39,7 @@ import serverutils.lib.util.permission.PermissionAPI;
 import serverutils.lib.util.text_components.Notification;
 import serverutils.lib.util.text_components.TextComponentParser;
 import serverutils.net.MessageUpdatePlayTime;
+import serverutils.net.MessageUpdateTabName;
 import serverutils.ranks.Ranks;
 
 public class ServerUtilitiesServerEventHandler {
@@ -176,7 +178,8 @@ public class ServerUtilitiesServerEventHandler {
                 }
 
                 if (afkEnabled) {
-                    ServerUtilitiesPlayerData data = ServerUtilitiesPlayerData.get(universe.getPlayer(player));
+                    ForgePlayer forgePlayer = universe.getPlayer(player);
+                    ServerUtilitiesPlayerData data = ServerUtilitiesPlayerData.get(forgePlayer);
                     boolean prevIsAfk = data.afkTime >= ServerUtilitiesConfig.afk.getNotificationTimer();
                     data.afkTime = System.currentTimeMillis() - player.func_154331_x();
                     boolean isAFK = data.afkTime >= ServerUtilitiesConfig.afk.getNotificationTimer();
@@ -186,6 +189,10 @@ public class ServerUtilitiesServerEventHandler {
                     }
 
                     if (prevIsAfk != isAFK) {
+                        if (ServerUtilitiesConfig.chat.replace_tab_names) {
+                            new MessageUpdateTabName(forgePlayer).sendToAll();
+                        }
+
                         for (EntityPlayerMP player1 : universe.server.getConfigurationManager().playerEntityList) {
                             EnumMessageLocation location = ServerUtilitiesPlayerData.get(universe.getPlayer(player1))
                                     .getAFKMessageLocation();

--- a/src/main/java/serverutils/mixin/Mixins.java
+++ b/src/main/java/serverutils/mixin/Mixins.java
@@ -17,10 +17,10 @@ import serverutils.ServerUtilities;
 public enum Mixins {
 
     COMMAND_PERMISSIONS(new Builder("Command Permissions").addTargetedMod(VANILLA).setSide(Side.BOTH)
-            .setPhase(Phase.EARLY).setApplyIf(() -> ranks.enabled && ranks.command_permissions).addMixinClasses(
-                    "minecraft.MixinCommandBase",
-                    "minecraft.MixinCommandHandler",
-                    "minecraft.MixinICommand")),;
+            .setPhase(Phase.EARLY).setApplyIf(() -> ranks.enabled && ranks.command_permissions)
+            .addMixinClasses("minecraft.MixinCommandBase", "minecraft.MixinCommandHandler", "minecraft.MixinICommand")),
+    REPLACE_TAB_NAMES(new Builder("Replace tab menu names").addTargetedMod(VANILLA).setSide(Side.CLIENT)
+            .setPhase(Phase.EARLY).addMixinClasses("forge.MixinGuiIngameForge")),;
 
     private final List<String> mixinClasses;
     private final Supplier<Boolean> applyIf;

--- a/src/main/java/serverutils/net/MessageUpdateTabName.java
+++ b/src/main/java/serverutils/net/MessageUpdateTabName.java
@@ -1,0 +1,93 @@
+package serverutils.net;
+
+import java.util.List;
+import java.util.Map;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiPlayerInfo;
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IChatComponent;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import serverutils.ServerUtilitiesConfig;
+import serverutils.client.gui.misc.GuiPlayerInfoWrapper;
+import serverutils.data.ServerUtilitiesPlayerData;
+import serverutils.lib.data.ForgePlayer;
+import serverutils.lib.io.DataIn;
+import serverutils.lib.io.DataOut;
+import serverutils.lib.net.MessageToClient;
+import serverutils.lib.net.NetworkWrapper;
+import serverutils.ranks.Ranks;
+
+public class MessageUpdateTabName extends MessageToClient {
+
+    private String name;
+    private IChatComponent displayComponent;
+    private boolean afk;
+
+    public MessageUpdateTabName() {}
+
+    public MessageUpdateTabName(ForgePlayer player) {
+        EntityPlayerMP playerMP = player.getPlayer();
+        name = playerMP.getCommandSenderName();
+        ServerUtilitiesPlayerData data = ServerUtilitiesPlayerData.get(player);
+        afk = data.afkTime >= ServerUtilitiesConfig.afk.getNotificationTimer();
+        if (Ranks.isActive()) {
+            displayComponent = data.getNameForChat(playerMP);
+        } else {
+            displayComponent = new ChatComponentText(playerMP.getDisplayName());
+        }
+    }
+
+    @Override
+    public NetworkWrapper getWrapper() {
+        return ServerUtilitiesNetHandler.GENERAL;
+    }
+
+    @Override
+    public void writeData(DataOut data) {
+        data.writeString(name);
+        data.writeTextComponent(displayComponent);
+        data.writeBoolean(afk);
+    }
+
+    @Override
+    public void readData(DataIn data) {
+        name = data.readString();
+        displayComponent = data.readTextComponent();
+        afk = data.readBoolean();
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void onMessage() {
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.isSingleplayer()) return;
+        NetHandlerPlayClient handler = mc.getNetHandler();
+        // noinspection unchecked
+        Map<String, GuiPlayerInfo> infoMap = (Map<String, GuiPlayerInfo>) handler.playerInfoMap;
+        List<GuiPlayerInfo> infoList = handler.playerInfoList;
+        GuiPlayerInfo info = infoMap.get(name);
+        if (info == null) return;
+
+        String displayName = displayComponent.getFormattedText().replaceAll("[<>]", "");
+
+        if (afk) {
+            displayName = EnumChatFormatting.GRAY + "[AFK] " + EnumChatFormatting.RESET + displayName;
+        }
+
+        if (info instanceof GuiPlayerInfoWrapper wrapper) {
+            wrapper.displayName = displayName;
+        } else {
+            infoMap.remove(name);
+            infoList.remove(info);
+            GuiPlayerInfoWrapper newInfo = new GuiPlayerInfoWrapper(info, displayName);
+            infoMap.put(name, newInfo);
+            infoList.add(newInfo);
+        }
+    }
+}

--- a/src/main/java/serverutils/net/ServerUtilitiesNetHandler.java
+++ b/src/main/java/serverutils/net/ServerUtilitiesNetHandler.java
@@ -22,6 +22,7 @@ public class ServerUtilitiesNetHandler {
         GENERAL.register(new MessageUpdatePlayTime());
         GENERAL.register(new MessageCommandsResponse());
         GENERAL.register(new MessageCommandsRequest());
+        GENERAL.register(new MessageUpdateTabName());
 
         CLAIMS.register(new MessageClaimedChunksRequest());
         CLAIMS.register(new MessageClaimedChunksUpdate());

--- a/src/main/resources/META-INF/serverutil_at.cfg
+++ b/src/main/resources/META-INF/serverutil_at.cfg
@@ -26,3 +26,4 @@ public net.minecraft.client.gui.inventory.GuiContainer field_147009_r #guitop
 public net.minecraft.tileentity.TileEntity field_145853_j # classToNameMap
 public net.minecraft.stats.StatBase field_75978_a # statName
 public net.minecraft.stats.StatBase field_75976_b # type
+public net.minecraft.client.network.NetHandlerPlayClient field_147310_i # playerInfoMap

--- a/src/mixins/java/serverutils/mixins/early/forge/MixinGuiIngameForge.java
+++ b/src/mixins/java/serverutils/mixins/early/forge/MixinGuiIngameForge.java
@@ -1,0 +1,28 @@
+package serverutils.mixins.early.forge;
+
+import net.minecraft.client.gui.GuiPlayerInfo;
+import net.minecraftforge.client.GuiIngameForge;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import serverutils.client.gui.misc.GuiPlayerInfoWrapper;
+
+@Mixin(GuiIngameForge.class)
+public abstract class MixinGuiIngameForge {
+
+    @ModifyExpressionValue(
+            method = "renderPlayerList",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/scoreboard/ScorePlayerTeam;formatPlayerName(Lnet/minecraft/scoreboard/Team;Ljava/lang/String;)Ljava/lang/String;"))
+    private String serverutilities$getDisplayName(String original, @Local GuiPlayerInfo player) {
+        if (player instanceof GuiPlayerInfoWrapper wrapper) {
+            return wrapper.displayName;
+        }
+        return original;
+    }
+}


### PR DESCRIPTION
This was a feature in FTBU, but the scoreboard is very different in 1.7.10 so it was never implemented here after the backport.
![su_tab](https://github.com/user-attachments/assets/8d6a7dc9-186c-49f0-9282-0450444b7484)

If AFK timer is enabled it will also display which players are currently AFK
![su_afk2](https://github.com/user-attachments/assets/aebccc28-a6b6-442d-bdea-a2c4720234c0)

This could also be done without mixins by changing the `name` field in GuiPlayerInfo, but some mods rely on that name matching with the local players name in order to determine their ping. 