### PR TITLE
Fix potential crash when adding player to rank

### DIFF
--- a/src/main/java/serverutils/client/gui/ranks/RankInst.java
+++ b/src/main/java/serverutils/client/gui/ranks/RankInst.java
@@ -19,7 +19,7 @@ public class RankInst extends FinalIDObject {
 
     public static final DataIn.Deserializer<RankInst> DESERIALIZER = data -> {
         RankInst inst = new RankInst(data.readString());
-        inst.parents = data.readCollection(DataIn.STRING);
+        inst.parents = new HashSet<>(data.readCollection(DataIn.STRING));
         inst.player = data.readString();
         inst.group = ConfigGroup.DESERIALIZER.read(data);
         return inst;


### PR DESCRIPTION
When a serialized collection only has a single element `DataIn.readCollection()` will return an immutable collection, which is of course not desired here.

Closes https://github.com/GTNewHorizons/ServerUtilities/issues/143