### PR TITLE
Fix display name not syncing again

### DIFF
--- a/src/main/java/serverutils/command/CmdNick.java
+++ b/src/main/java/serverutils/command/CmdNick.java
@@ -1,20 +1,16 @@
 package serverutils.command;
 
-import java.util.Collections;
-
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.util.EnumChatFormatting;
 
 import serverutils.ServerUtilities;
-import serverutils.ServerUtilitiesConfig;
 import serverutils.ServerUtilitiesPermissions;
 import serverutils.data.ServerUtilitiesPlayerData;
 import serverutils.lib.command.CmdBase;
 import serverutils.lib.command.CommandUtils;
 import serverutils.lib.data.ForgePlayer;
 import serverutils.lib.util.StringUtils;
-import serverutils.net.MessageUpdateTabName;
 
 public class CmdNick extends CmdBase {
 
@@ -47,10 +43,6 @@ public class CmdNick extends CmdBase {
 
             player.getPlayer().addChatMessage(
                     ServerUtilities.lang(player.getPlayer(), "serverutilities.lang.nickname_changed", name));
-        }
-
-        if (ServerUtilitiesConfig.chat.replace_tab_names) {
-            new MessageUpdateTabName(Collections.singleton(player)).sendToAll();
         }
     }
 }

--- a/src/main/java/serverutils/command/CmdNickFor.java
+++ b/src/main/java/serverutils/command/CmdNickFor.java
@@ -1,19 +1,15 @@
 package serverutils.command;
 
-import java.util.Collections;
-
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.util.EnumChatFormatting;
 
 import serverutils.ServerUtilities;
-import serverutils.ServerUtilitiesConfig;
 import serverutils.data.ServerUtilitiesPlayerData;
 import serverutils.lib.command.CmdBase;
 import serverutils.lib.command.CommandUtils;
 import serverutils.lib.data.ForgePlayer;
 import serverutils.lib.util.StringUtils;
-import serverutils.net.MessageUpdateTabName;
 
 public class CmdNickFor extends CmdBase {
 
@@ -39,10 +35,6 @@ public class CmdNickFor extends CmdBase {
             }
 
             sender.addChatMessage(ServerUtilities.lang(sender, "serverutilities.lang.nickname_changed", name));
-        }
-
-        if (ServerUtilitiesConfig.chat.replace_tab_names) {
-            new MessageUpdateTabName(Collections.singleton(player)).sendToAll();
         }
     }
 }

--- a/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesPlayerEventHandler.java
@@ -1,7 +1,5 @@
 package serverutils.handlers;
 
-import java.util.Collections;
-
 import net.minecraft.block.Block;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.Entity;
@@ -93,7 +91,6 @@ public class ServerUtilitiesPlayerEventHandler {
         }
 
         if (ServerUtilitiesConfig.chat.replace_tab_names) {
-            new MessageUpdateTabName(Collections.singleton(event.getPlayer())).sendToAll();
             new MessageUpdateTabName(Universe.get().getOnlinePlayers()).sendTo(player);
         }
 

--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -79,7 +79,7 @@ public class ServerUtilitiesServerEventHandler {
 
         IChatComponent main = new ChatComponentText("");
         ServerUtilitiesPlayerData data = ServerUtilitiesPlayerData.get(Universe.get().getPlayer(player));
-        main.appendSibling(data.getNameForChat(player));
+        main.appendSibling(data.getNameForChat());
 
         String message = event.message.trim();
 

--- a/src/main/java/serverutils/net/MessageRankModify.java
+++ b/src/main/java/serverutils/net/MessageRankModify.java
@@ -2,25 +2,18 @@ package serverutils.net;
 
 import static serverutils.ServerUtilitiesPermissions.RANK_EDIT;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ChatComponentText;
 
-import serverutils.ServerUtilitiesConfig;
-import serverutils.ServerUtilitiesPermissions;
 import serverutils.client.gui.ranks.RankInst;
 import serverutils.lib.config.ConfigValueInstance;
-import serverutils.lib.data.ForgePlayer;
-import serverutils.lib.data.Universe;
 import serverutils.lib.io.DataIn;
 import serverutils.lib.io.DataOut;
 import serverutils.lib.net.MessageToServer;
 import serverutils.lib.net.NetworkWrapper;
 import serverutils.lib.util.permission.PermissionAPI;
-import serverutils.ranks.PlayerRank;
 import serverutils.ranks.Rank;
 import serverutils.ranks.Ranks;
 
@@ -62,40 +55,22 @@ public class MessageRankModify extends MessageToServer {
             return;
         }
 
-        boolean updateNames = false;
         boolean shouldSave = false;
         for (ConfigValueInstance value : inst.group.getValues()) {
             Rank.Entry entry = rank.setPermission(value.getId(), value.getValue());
             if (entry == null) continue;
-            if (entry.node.equals(ServerUtilitiesPermissions.CHAT_NAME_FORMAT)) {
-                updateNames = true;
-            }
             shouldSave = true;
         }
 
         for (String removed : removedEntries) {
             Rank.Entry entry = rank.setPermission(removed, "");
             if (entry == null) continue;
-            if (entry.node.equals(ServerUtilitiesPermissions.CHAT_NAME_FORMAT)) {
-                updateNames = true;
-            }
             shouldSave = true;
 
         }
 
         if (shouldSave) {
             Ranks.INSTANCE.save();
-        }
-
-        if (ServerUtilitiesConfig.chat.replace_tab_names && updateNames) {
-            List<ForgePlayer> toUpdate = new ArrayList<>();
-            for (PlayerRank playerRank : Ranks.INSTANCE.playerRanks.values()) {
-                if (!playerRank.getParents().contains(rank)) continue;
-                ForgePlayer fp = Universe.get().getPlayer(playerRank.profile);
-                if (fp == null || !fp.isOnline()) continue;
-                toUpdate.add(fp);
-            }
-            new MessageUpdateTabName(toUpdate).sendToAll();
         }
     }
 }

--- a/src/main/java/serverutils/net/MessageUpdateTabName.java
+++ b/src/main/java/serverutils/net/MessageUpdateTabName.java
@@ -10,8 +10,6 @@ import javax.annotation.Nullable;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiPlayerInfo;
 import net.minecraft.client.network.NetHandlerPlayClient;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
 
@@ -25,7 +23,6 @@ import serverutils.lib.io.DataIn;
 import serverutils.lib.io.DataOut;
 import serverutils.lib.net.MessageToClient;
 import serverutils.lib.net.NetworkWrapper;
-import serverutils.ranks.Ranks;
 
 public class MessageUpdateTabName extends MessageToClient {
 
@@ -35,19 +32,16 @@ public class MessageUpdateTabName extends MessageToClient {
 
     public MessageUpdateTabName(Collection<ForgePlayer> players) {
         for (ForgePlayer player : players) {
-            EntityPlayerMP playerMP = player.getPlayer();
-            String name = playerMP.getCommandSenderName();
             ServerUtilitiesPlayerData data = ServerUtilitiesPlayerData.get(player);
             boolean afk = data.afkTime >= ServerUtilitiesConfig.afk.getNotificationTimer();
-            IChatComponent displayComponent;
-            if (Ranks.isActive()) {
-                displayComponent = data.getNameForChat(playerMP);
-            } else {
-                displayComponent = new ChatComponentText(playerMP.getDisplayName());
-            }
-
-            entries.add(new TabNameEntry(name, displayComponent, afk));
+            entries.add(new TabNameEntry(player.getName(), data.getNameForChat(), afk));
         }
+    }
+
+    public MessageUpdateTabName(ForgePlayer player, IChatComponent displayName) {
+        ServerUtilitiesPlayerData data = ServerUtilitiesPlayerData.get(player);
+        boolean afk = data.afkTime >= ServerUtilitiesConfig.afk.getNotificationTimer();
+        entries.add(new TabNameEntry(player.getName(), displayName, afk));
     }
 
     @Override


### PR DESCRIPTION
This changes it to sync the display name whenever it is updated if `replace_tab_names` is enabled and should fix any remaining sync issues.

Closes https://github.com/GTNewHorizons/ServerUtilities/issues/149