### PR TITLE
Fix a few command issues

### DIFF
--- a/src/main/java/serverutils/lib/command/CmdTreeHelp.java
+++ b/src/main/java/serverutils/lib/command/CmdTreeHelp.java
@@ -1,13 +1,13 @@
 package serverutils.lib.command;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import net.minecraft.command.CommandHelp;
 import net.minecraft.command.ICommand;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.util.StatCollector;
 
 public class CmdTreeHelp extends CommandHelp {
 
@@ -32,8 +32,13 @@ public class CmdTreeHelp extends CommandHelp {
             }
         }
 
-        Collections.sort(list);
+        list.sort(null);
         return list;
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return StatCollector.translateToLocal(parent.getCommandUsage(sender)) + " help";
     }
 
     @Override

--- a/src/mixins/java/serverutils/mixins/early/minecraft/MixinCommandHandler.java
+++ b/src/mixins/java/serverutils/mixins/early/minecraft/MixinCommandHandler.java
@@ -1,5 +1,8 @@
 package serverutils.mixins.early.minecraft;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandHandler;
 import net.minecraft.command.ICommand;
@@ -31,6 +34,9 @@ import serverutils.ranks.Ranks;
 @Mixin(CommandHandler.class)
 public abstract class MixinCommandHandler {
 
+    @Unique
+    private static final Matcher PERMISSION_REPLACE_MATCHER = Pattern.compile("[^a-zA-Z0-9._]").matcher("");
+
     @ModifyExpressionValue(
             method = { "getPossibleCommands(Lnet/minecraft/command/ICommandSender;)Ljava/util/List;",
                     "executeCommand" },
@@ -58,7 +64,7 @@ public abstract class MixinCommandHandler {
         String node = (container == null ? Rank.NODE_COMMAND : (Rank.NODE_COMMAND + '.' + container.getModId())) + "."
                 + command.getCommandName();
         ICommandWithPermission cmd = (ICommandWithPermission) command;
-        cmd.serverutilities$setPermissionNode(node.toLowerCase());
+        cmd.serverutilities$setPermissionNode(PERMISSION_REPLACE_MATCHER.reset(node.toLowerCase()).replaceAll("_"));
         cmd.serverutilities$setModName(container == null ? "Minecraft" : container.getName());
         serverUtilities$registerPermissions(cmd);
     }


### PR DESCRIPTION
Blood magic overrides the lang key for the default `/help` commands usage with its own https://github.com/GTNewHorizons/BloodMagic/blob/2e95450cf0601c30e82126614d86b59ad02f09f0/src/main/resources/assets/alchemicalwizardry/lang/en_US.lang#L349. I can't imagine that it's actually intended but to fix it I've just hardcoded the help subcommand to be `/insert_parent_command help` which will also prevent any future issues.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18323

The `ConfigGroup` class that the rank config ui uses only support periods and underscores as special characters in the name which caused some botania commands (`/botania-open` & `/botania-share`) to be saved with incorrect permission nodes. This is fixed by simply replacing any special character that is not a period or underscore in the command permissions with an underscore.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18322