### PR TITLE
Fix aurora config registration

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesCommon.java
+++ b/src/main/java/serverutils/ServerUtilitiesCommon.java
@@ -154,7 +154,7 @@ public class ServerUtilitiesCommon {
         MinecraftForge.EVENT_BUS.register(ServerUtilitiesUniverseData.INST);
         MinecraftForge.EVENT_BUS.register(ServerUtilitiesPermissions.INST);
         FMLCommonHandler.instance().bus().register(ServerUtilitiesServerEventHandler.INST);
-        if (AuroraConfig.enable) {
+        if (AuroraConfig.general.enable) {
             MinecraftForge.EVENT_BUS.register(AuroraMinecraftHandler.INST);
             FMLCommonHandler.instance().bus().register(AuroraMinecraftHandler.INST);
         }
@@ -259,7 +259,7 @@ public class ServerUtilitiesCommon {
     public void onServerStarting(FMLServerStartingEvent event) {
         ServerUtilitiesCommands.registerCommands(event);
 
-        if (AuroraConfig.enable) {
+        if (AuroraConfig.general.enable) {
             Aurora.start(event.getServer());
         }
     }

--- a/src/main/java/serverutils/aurora/Aurora.java
+++ b/src/main/java/serverutils/aurora/Aurora.java
@@ -7,16 +7,16 @@ public class Aurora {
     private static AuroraServer server;
 
     public static void start(MinecraftServer s) {
-        if (AuroraConfig.enable) {
+        if (AuroraConfig.general.enable) {
             if (server == null) {
-                server = new AuroraServer(s, AuroraConfig.port);
+                server = new AuroraServer(s, AuroraConfig.general.port);
                 server.start();
             }
         }
     }
 
     public static void stop() {
-        if (AuroraConfig.enable) {
+        if (AuroraConfig.general.enable) {
             if (server != null) {
                 server.shutdown();
                 server = null;

--- a/src/main/java/serverutils/aurora/AuroraConfig.java
+++ b/src/main/java/serverutils/aurora/AuroraConfig.java
@@ -1,47 +1,57 @@
 package serverutils.aurora;
 
 import com.gtnewhorizon.gtnhlib.config.Config;
+import serverutils.ServerUtilities;
 
-@Config(modid = "serverutilities", filename = "aurora", configSubDirectory = "../serverutilities/")
+@Config(modid = ServerUtilities.MOD_ID, category = "", filename = "aurora", configSubDirectory = "../serverutilities/")
 public class AuroraConfig {
 
-    @Config.Comment("Enable the localhost server")
-    @Config.DefaultBoolean(false)
-    public static boolean enable;
+    public static final General general = new General();
+    public static final Pages pages = new Pages();
 
-    @Config.Comment("Enable the modlist page")
-    @Config.DefaultEnum("ENABLED")
-    public static PageType modlist_page;
+    public static class General {
+        @Config.Comment("Enable the localhost server")
+        @Config.DefaultBoolean(false)
+        public boolean enable;
 
-    @Config.Comment("Enable the modlist page")
-    @Config.DefaultEnum("ENABLED")
-    public static PageType world_info_json;
+        @Config.Comment("Webserver Port ID")
+        @Config.DefaultInt(48574)
+        @Config.RangeInt(min = 1024, max = 65535)
+        public int port;
+    }
 
-    @Config.Comment("Enable the world info page")
-    @Config.DefaultEnum("ENABLED")
-    public static PageType player_list_table;
+    public static class Pages {
 
-    @Config.Comment("Enable the playerlist table page")
-    @Config.DefaultEnum("ENABLED")
-    public static PageType player_list_json;
+        @Config.Comment("Enable the modlist page")
+        @Config.DefaultEnum("ENABLED")
+        public PageType modlist_page;
 
-    @Config.Comment("Enable the playerlist json page")
-    @Config.DefaultEnum("REQUIRES_AUTH")
-    public static PageType player_rank_page;
+        @Config.Comment("Enable the modlist page")
+        @Config.DefaultEnum("ENABLED")
+        public PageType world_info_json;
 
-    @Config.Comment("Enable the player rank page from Server Utilities")
-    @Config.DefaultEnum("ENABLED")
-    public static PageType command_list_page;
+        @Config.Comment("Enable the world info page")
+        @Config.DefaultEnum("ENABLED")
+        public PageType player_list_table;
 
-    @Config.Comment("Enable the command list page from Server Utilities")
-    @Config.DefaultEnum("ENABLED")
-    public static PageType permission_list_page;
+        @Config.Comment("Enable the playerlist table page")
+        @Config.DefaultEnum("ENABLED")
+        public PageType player_list_json;
 
-    @Config.Comment("Exclude mods from the modlist")
-    @Config.DefaultStringList({})
-    public static String[] modlist_excluded_mods;
+        @Config.Comment("Enable the playerlist json page")
+        @Config.DefaultEnum("REQUIRES_AUTH")
+        public PageType player_rank_page;
 
-    @Config.Comment("Webserver Port ID")
-    @Config.DefaultInt(48574)
-    public static int port;
+        @Config.Comment("Enable the player rank page from Server Utilities")
+        @Config.DefaultEnum("ENABLED")
+        public PageType command_list_page;
+
+        @Config.Comment("Enable the command list page from Server Utilities")
+        @Config.DefaultEnum("ENABLED")
+        public PageType permission_list_page;
+
+        @Config.Comment("Exclude mods from the modlist")
+        @Config.DefaultStringList({})
+        public String[] modlist_excluded_mods;
+    }
 }

--- a/src/main/java/serverutils/aurora/AuroraConfig.java
+++ b/src/main/java/serverutils/aurora/AuroraConfig.java
@@ -1,6 +1,7 @@
 package serverutils.aurora;
 
 import com.gtnewhorizon.gtnhlib.config.Config;
+
 import serverutils.ServerUtilities;
 
 @Config(modid = ServerUtilities.MOD_ID, category = "", filename = "aurora", configSubDirectory = "../serverutilities/")
@@ -10,6 +11,7 @@ public class AuroraConfig {
     public static final Pages pages = new Pages();
 
     public static class General {
+
         @Config.Comment("Enable the localhost server")
         @Config.DefaultBoolean(false)
         public boolean enable;

--- a/src/main/java/serverutils/aurora/mc/AuroraMinecraftHandler.java
+++ b/src/main/java/serverutils/aurora/mc/AuroraMinecraftHandler.java
@@ -46,7 +46,7 @@ public class AuroraMinecraftHandler {
     public void onPageEvent(AuroraPageEvent event) {
 
         if (event.checkPath("modlist", "*")) {
-            HashSet<String> set = new HashSet<>(Arrays.asList(AuroraConfig.modlist_excluded_mods));
+            HashSet<String> set = new HashSet<>(Arrays.asList(AuroraConfig.pages.modlist_excluded_mods));
 
             if (!set.contains(event.getSplitUri()[1])) {
                 ModContainer modContainer = Loader.instance().getIndexedModList().get(event.getSplitUri()[1]);
@@ -56,7 +56,7 @@ public class AuroraMinecraftHandler {
                 }
             }
         } else if (event.checkPath("modlist")) {
-            event.returnPage(new ModListPage(new HashSet<>(Arrays.asList(AuroraConfig.modlist_excluded_mods))));
+            event.returnPage(new ModListPage(new HashSet<>(Arrays.asList(AuroraConfig.pages.modlist_excluded_mods))));
         } else if (event.checkPath("minecraft", "online_players")) {
             event.returnPage(new PlayerListTable(event.getAuroraServer().getServer()));
         } else if (event.checkPath("minecraft", "online_players.json")) {

--- a/src/main/java/serverutils/aurora/mc/CommandListPage.java
+++ b/src/main/java/serverutils/aurora/mc/CommandListPage.java
@@ -35,7 +35,7 @@ public class CommandListPage extends HTTPWebPage {
 
     @Override
     public PageType getPageType() {
-        return AuroraConfig.command_list_page;
+        return AuroraConfig.pages.command_list_page;
     }
 
     @Override

--- a/src/main/java/serverutils/aurora/mc/ModListPage.java
+++ b/src/main/java/serverutils/aurora/mc/ModListPage.java
@@ -30,7 +30,7 @@ public class ModListPage extends HTTPWebPage {
 
     @Override
     public PageType getPageType() {
-        return AuroraConfig.modlist_page;
+        return AuroraConfig.pages.modlist_page;
     }
 
     @Override

--- a/src/main/java/serverutils/aurora/mc/ModPage.java
+++ b/src/main/java/serverutils/aurora/mc/ModPage.java
@@ -26,7 +26,7 @@ public class ModPage extends HTTPWebPage {
 
     @Override
     public PageType getPageType() {
-        return AuroraConfig.modlist_page;
+        return AuroraConfig.pages.modlist_page;
     }
 
     @Override

--- a/src/main/java/serverutils/aurora/mc/PermissionListPage.java
+++ b/src/main/java/serverutils/aurora/mc/PermissionListPage.java
@@ -50,7 +50,7 @@ public class PermissionListPage extends HTTPWebPage {
 
     @Override
     public PageType getPageType() {
-        return AuroraConfig.permission_list_page;
+        return AuroraConfig.pages.permission_list_page;
     }
 
     @Override

--- a/src/main/java/serverutils/aurora/mc/PlayerListJson.java
+++ b/src/main/java/serverutils/aurora/mc/PlayerListJson.java
@@ -21,7 +21,7 @@ public class PlayerListJson extends JsonWebPage {
 
     @Override
     public PageType getPageType() {
-        return AuroraConfig.player_list_json;
+        return AuroraConfig.pages.player_list_json;
     }
 
     @Override

--- a/src/main/java/serverutils/aurora/mc/PlayerListTable.java
+++ b/src/main/java/serverutils/aurora/mc/PlayerListTable.java
@@ -28,7 +28,7 @@ public class PlayerListTable extends HTTPWebPage {
 
     @Override
     public PageType getPageType() {
-        return AuroraConfig.player_list_table;
+        return AuroraConfig.pages.player_list_table;
     }
 
     @Override

--- a/src/main/java/serverutils/aurora/mc/RankPage.java
+++ b/src/main/java/serverutils/aurora/mc/RankPage.java
@@ -29,7 +29,7 @@ public class RankPage extends HTTPWebPage {
 
     @Override
     public PageType getPageType() {
-        return AuroraConfig.player_rank_page;
+        return AuroraConfig.pages.player_rank_page;
     }
 
     @Override

--- a/src/main/java/serverutils/aurora/mc/WorldInfoJson.java
+++ b/src/main/java/serverutils/aurora/mc/WorldInfoJson.java
@@ -20,7 +20,7 @@ public class WorldInfoJson extends JsonWebPage {
 
     @Override
     public PageType getPageType() {
-        return AuroraConfig.world_info_json;
+        return AuroraConfig.pages.world_info_json;
     }
 
     @Override

--- a/src/main/java/serverutils/core/ServerUtilitiesCore.java
+++ b/src/main/java/serverutils/core/ServerUtilitiesCore.java
@@ -10,6 +10,7 @@ import com.gtnewhorizon.gtnhmixins.IEarlyMixinLoader;
 
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 import serverutils.ServerUtilitiesConfig;
+import serverutils.aurora.AuroraConfig;
 import serverutils.mixin.Mixins;
 
 public class ServerUtilitiesCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
@@ -17,6 +18,7 @@ public class ServerUtilitiesCore implements IFMLLoadingPlugin, IEarlyMixinLoader
     static {
         try {
             ConfigurationManager.registerConfig(ServerUtilitiesConfig.class);
+            ConfigurationManager.registerConfig(AuroraConfig.class);
         } catch (ConfigException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Aurora config was not being registered after the GTNHLib configuration conversion. Fixed by registering AuroraConfig alongside ServerUtilitiesConfig. The structure of AuroraConfig was modified to match the config file structure that folks would have from previous versions of GT:NH.

Closes #154 