### PR TITLE
Fix backup folder not being created

### DIFF
--- a/src/main/java/serverutils/task/backup/BackupTask.java
+++ b/src/main/java/serverutils/task/backup/BackupTask.java
@@ -49,8 +49,9 @@ public class BackupTask extends Task {
     private boolean post = false;
 
     static {
-        BACKUP_FOLDER = FileUtils.newFile(
-                backups.backup_folder_path.isEmpty() ? new File("/backups/") : new File(backups.backup_folder_path));
+        BACKUP_FOLDER = backups.backup_folder_path.isEmpty() ? new File("/backups/")
+                : new File(backups.backup_folder_path);
+        if (!BACKUP_FOLDER.exists()) BACKUP_FOLDER.mkdirs();
         clearOldBackups();
         ServerUtilities.LOGGER.info("Backups folder - {}", BACKUP_FOLDER.getAbsolutePath());
     }


### PR DESCRIPTION
`FileUtils.newFile()` is great for normal files as it'll both create the file on disk along with all the parent directories, but it creates it as a file not as a directory which obviously isn't ideal here... (idek why i changed it to begin with)