### PR TITLE
Fix nbtedit using the wrong datatypes.

### DIFF
--- a/src/main/java/serverutils/client/gui/GuiEditNBT.java
+++ b/src/main/java/serverutils/client/gui/GuiEditNBT.java
@@ -212,7 +212,12 @@ public class GuiEditNBT extends GuiBase {
             if (set) {
                 switch (nbt.getId()) {
                     case Constants.NBT.TAG_BYTE:
+                        nbt = new NBTTagByte((byte) Math.max(Byte.MIN_VALUE, Math.min(Byte.MAX_VALUE, value.getInt())));
+                        break;
                     case Constants.NBT.TAG_SHORT:
+                        nbt = new NBTTagShort(
+                                (short) Math.max(Short.MIN_VALUE, Math.min(Short.MAX_VALUE, value.getInt())));
+                        break;
                     case Constants.NBT.TAG_INT:
                         nbt = new NBTTagInt(value.getInt());
                         break;
@@ -220,6 +225,8 @@ public class GuiEditNBT extends GuiBase {
                         nbt = new NBTTagLong(Long.parseLong(value.getString()));
                         break;
                     case Constants.NBT.TAG_FLOAT:
+                        nbt = new NBTTagFloat((float) value.getDouble());
+                        break;
                     case Constants.NBT.TAG_DOUBLE:
                     case Constants.NBT.TAG_ANY_NUMERIC:
                         nbt = new NBTTagDouble(value.getDouble());


### PR DESCRIPTION
Numeric NBT types aren't implicitly converted at runtime, so if you have something that looks for a byte like a bool, it gets annoying as it won't be able to read the int you just stored there; I use this a lot for testing the crop rework.

https://github.com/user-attachments/assets/6b1dde58-8e9d-4a25-a4d9-cce4c689c592

This PR fixes this problematic behaviour.

https://github.com/user-attachments/assets/e3552c06-71f8-4056-99cd-549a17ae2440

