### PR TITLE
Fix `max_folder_size` not working for smaller worlds

### DIFF
--- a/src/main/java/serverutils/command/CmdBackup.java
+++ b/src/main/java/serverutils/command/CmdBackup.java
@@ -64,7 +64,7 @@ public class CmdBackup extends CmdTreeBase {
         public void processCommand(ICommandSender sender, String[] args) {
             String sizeW = FileUtils.getSizeString(sender.getEntityWorld().getSaveHandler().getWorldDirectory());
             String sizeT = FileUtils.getSizeString(BackupTask.BACKUP_FOLDER);
-            sender.addChatMessage(ServerUtilities.lang(sender, "cmd.backup_not_running", sizeW, sizeT));
+            sender.addChatMessage(ServerUtilities.lang(sender, "cmd.backup_size", sizeW, sizeT));
         }
     }
 }


### PR DESCRIPTION
The `max_folder_size` size option worked fine if you happen to have a world larger than 1gb, but didn't work at all for smaller worlds as `FileUtils.getSize(file, SizeUnit.GB)` would return 0.  This changes it to just deal with the sizes in bytes which is the more sane way to do it anyways.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18613