### PR TITLE
Fix player ranks ui becoming unreadable if players have tons of ranks

### DIFF
--- a/src/main/java/serverutils/client/gui/ranks/GuiPlayerRanks.java
+++ b/src/main/java/serverutils/client/gui/ranks/GuiPlayerRanks.java
@@ -2,8 +2,8 @@ package serverutils.client.gui.ranks;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.util.StatCollector;
 
 import serverutils.lib.gui.Button;
@@ -23,20 +23,20 @@ public class GuiPlayerRanks extends GuiButtonListBase {
     private class PlayerEntry extends Button implements Comparable<PlayerEntry> {
 
         private final String username;
-        private final String ranks;
+        private final String allRanks;
+        private final String highestRank;
         private final RankInst playerRank;
 
         public PlayerEntry(Panel panel, String u, RankInst r) {
             super(panel);
             username = u;
             playerRank = r;
-            List<String> sortedParents = r.parents.stream().sorted(String::compareToIgnoreCase)
-                    .collect(Collectors.toList());
-            ranks = getRanksAsString(sortedParents);
+            allRanks = getRanksAsString(r.parents);
+            highestRank = r.parents.isEmpty() ? "No assigned rank" : StringUtils.firstUppercase(r.parents.get(0));
 
             Theme theme = getTheme();
             usernameSize = Math.max(usernameSize, theme.getStringWidth(username) + 8);
-            valueSize = Math.max(valueSize, theme.getStringWidth(ranks) + 8);
+            valueSize = Math.max(valueSize, theme.getStringWidth(highestRank) + 8);
 
             setSize(usernameSize + valueSize, 14);
         }
@@ -62,7 +62,11 @@ public class GuiPlayerRanks extends GuiButtonListBase {
         }
 
         @Override
-        public void addMouseOverText(List<String> list) {}
+        public void addMouseOverText(List<String> list) {
+            if (playerRank.parents.size() <= 1) return;
+            list.add("All assigned ranks:");
+            list.addAll(Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(allRanks, 200));
+        }
 
         @Override
         public void draw(Theme theme, int x, int y, int w, int h) {
@@ -73,7 +77,7 @@ public class GuiPlayerRanks extends GuiButtonListBase {
             theme.drawString(username, x + 4, textY, Theme.SHADOW);
 
             theme.drawButton(x + usernameSize, y, valueSize, h, type);
-            theme.drawString(ranks, x + usernameSize + 4, textY, Theme.SHADOW);
+            theme.drawString(highestRank, x + usernameSize + 4, textY, Theme.SHADOW);
         }
 
         @Override

--- a/src/main/java/serverutils/client/gui/ranks/RankInst.java
+++ b/src/main/java/serverutils/client/gui/ranks/RankInst.java
@@ -1,7 +1,7 @@
 package serverutils.client.gui.ranks;
 
-import java.util.Collection;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 
 import serverutils.lib.config.ConfigGroup;
 import serverutils.lib.io.DataIn;
@@ -19,19 +19,19 @@ public class RankInst extends FinalIDObject {
 
     public static final DataIn.Deserializer<RankInst> DESERIALIZER = data -> {
         RankInst inst = new RankInst(data.readString());
-        inst.parents = new HashSet<>(data.readCollection(DataIn.STRING));
+        inst.parents = new ArrayList<>(data.readCollection(DataIn.STRING));
         inst.player = data.readString();
         inst.group = ConfigGroup.DESERIALIZER.read(data);
         return inst;
     };
 
-    public Collection<String> parents;
+    public List<String> parents;
     public ConfigGroup group;
     public String player;
 
     public RankInst(String id) {
         super(id);
-        parents = new HashSet<>();
+        parents = new ArrayList<>();
         group = ConfigGroup.newGroup("");
         player = "";
     }

--- a/src/main/java/serverutils/net/MessageRanks.java
+++ b/src/main/java/serverutils/net/MessageRanks.java
@@ -5,7 +5,7 @@ import static serverutils.ServerUtilitiesPermissions.LEADERBOARD_PREFIX;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 import net.minecraft.command.ICommand;
@@ -16,6 +16,7 @@ import net.minecraft.util.IChatComponent;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import it.unimi.dsi.fastutil.ints.IntComparators;
 import serverutils.ServerUtilitiesPermissions;
 import serverutils.client.gui.ranks.GuiRanks;
 import serverutils.client.gui.ranks.RankInst;
@@ -70,7 +71,7 @@ public class MessageRanks extends MessageToClient {
 
             inst.group = group;
 
-            Collection<String> parents = new HashSet<>();
+            List<String> parents = new ArrayList<>();
             for (Rank rs : rank.getParents()) {
                 parents.add(rs.getId());
             }
@@ -90,7 +91,10 @@ public class MessageRanks extends MessageToClient {
             inst.player = player.getName();
 
             PlayerRank pRank = r.getPlayerRank(player.getProfile());
-            for (Rank rank : pRank.getActualParents()) {
+            List<Rank> sortedParents = new ArrayList<>(pRank.getActualParents());
+            sortedParents
+                    .sort((r1, r2) -> IntComparators.OPPOSITE_COMPARATOR.compare(r1.getPriority(), r2.getPriority()));
+            for (Rank rank : sortedParents) {
                 inst.parents.add(rank.getId());
             }
 


### PR DESCRIPTION
Fixes this mess from StoneLegion
![ahhhh_so_many_ranks](https://github.com/user-attachments/assets/5c903e19-6e67-4790-849b-425a24de17bd)
 
Now only the players most prominent rank (the one with highest priority) will be displayed and the rest have been moved to a hover tooltip
![player_rank_ui](https://github.com/user-attachments/assets/bcad0f4e-c419-4a56-9cad-a801a9a33ba3)