### PR TITLE
Fix chunk decay not working for teams that have been inactive for ages

### DIFF
--- a/src/main/java/serverutils/lib/data/ForgeTeam.java
+++ b/src/main/java/serverutils/lib/data/ForgeTeam.java
@@ -659,6 +659,13 @@ public class ForgeTeam extends FinalIDObject implements INBTSerializable<NBTTagC
     }
 
     public long getLastActivity() {
+        if (lastActivity == 0) {
+            long latestActivity = 0;
+            for (ForgePlayer player : getMembers()) {
+                latestActivity = Math.max(player.getLastTimeSeen(), latestActivity);
+            }
+            lastActivity = System.currentTimeMillis() - Ticks.get(universe.ticks.ticks() - latestActivity).millis();
+        }
         return lastActivity;
     }
 


### PR DESCRIPTION
`getLastActivity()` would always return 0 if the team didn't have any activity after the chunk decay feature was introduced which meant their claims/chunkloads would never be removed.

Fixes https://discord.com/channels/181078474394566657/305737190195986433/1331354851573235843