### PR TITLE
Fix player sleeping message

### DIFF
--- a/src/mixins/java/serverutils/mixins/early/minecraft/MixinWorldServer_SleepPercentage.java
+++ b/src/mixins/java/serverutils/mixins/early/minecraft/MixinWorldServer_SleepPercentage.java
@@ -4,6 +4,8 @@ import static serverutils.ServerUtilitiesConfig.afk;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -46,6 +48,9 @@ public abstract class MixinWorldServer_SleepPercentage extends World {
     @Unique
     private List<EntityPlayer> sleepingPlayers;
 
+    @Unique
+    private Set<UUID> previousSleepingPlayers;
+
     /**
      * We need to access this.playerEntities from the superclass, so we're extending World, and need this fake
      * constructor to make Java happy
@@ -69,27 +74,33 @@ public abstract class MixinWorldServer_SleepPercentage extends World {
                 sleepingPlayers = new ArrayList<>();
             }
             sleepingPlayers.clear();
-            int cap = (int) Math.ceil(serverutilities$getListWithoutAFK(this.playerEntities).size() * percent * 0.01f);
+            int playerCountWithoutAFK = serverutilities$getListWithoutAFK(this.playerEntities).size();
+            int cap = (int) Math.ceil(playerCountWithoutAFK * percent * 0.01f);
             for (EntityPlayer player : this.playerEntities) {
                 if (player.isPlayerSleeping()) {
                     sleepingPlayers.add(player);
-                    theSleeper = player;
+                    // to find the player who was the last to sleep
+                    if (!previousSleepingPlayers.contains(player.getUniqueID())) {
+                        theSleeper = player;
+                    }
                     if (sleepingPlayers.size() >= cap) {
                         this.allPlayersSleeping = true;
                         break;
                     }
                 }
             }
+            previousSleepingPlayers = sleepingPlayers.stream().map(EntityPlayer::getUniqueID)
+                    .collect(Collectors.toSet());
             // if server is dedicated, or open to lan
             if (!sleepingPlayers.isEmpty() && cap > 0 && theSleeper != null && (!mcServer.isSinglePlayer())) {
                 for (EntityPlayer player : this.playerEntities) {
-                    String percentString = String.format("%d", (sleepingPlayers.size() * 100) / cap);
+                    String percentString = String.format("%d", (sleepingPlayers.size() * 100) / playerCountWithoutAFK);
                     player.addChatMessage(
                             new ChatComponentTranslation(
                                     "serverutilities.world.players_sleeping",
                                     theSleeper.getDisplayName(),
                                     sleepingPlayers.size(),
-                                    cap,
+                                    playerCountWithoutAFK,
                                     percentString));
                 }
             }


### PR DESCRIPTION
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19632

>We are also seeing some buggy behavior from the SU functionality. The first player to sleep is called out repeatedly in the messages, even though other players were sleeping. The 50% value doesn't seem to actually work reliably either.

Display the name of the player who went to sleep last in the message.

Updated the sleep percentage display logic. The original formula used `sleeping players / required players`, which may differ from 1.17+ behavior and cause confusion.

