### PR TITLE
Add config for pregeneration speed

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -665,7 +665,7 @@ public class ServerUtilitiesConfig {
         @Config.DefaultInt(1)
         public int chunksPerTick;
 
-        @Config.Comment("The maximum time to spend on pregeneration per tick, in milliseconds.")
+        @Config.Comment("The maximum time to spend on pregeneration per tick, in milliseconds. Note that chunk unloading also takes time, and isn't limited by this config!")
         @Config.DefaultFloat(25)
         public float timeLimitMs;
 

--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -36,6 +36,7 @@ public class ServerUtilitiesConfig {
     public static final General general = new General();
     public static final Teams teams = new Teams();
     public static final Tasks tasks = new Tasks();
+    public static final Pregen pregen = new Pregen();
 
     public static class General {
 
@@ -656,5 +657,20 @@ public class ServerUtilitiesConfig {
         }
 
         public final Cleanup cleanup = new Cleanup();
+    }
+
+    public static class Pregen {
+
+        @Config.Comment("When pregeneration is active, queue this many chunks per tick.")
+        @Config.DefaultInt(1)
+        public int chunksPerTick;
+
+        @Config.Comment("The maximum time to spend on pregeneration per tick, in milliseconds.")
+        @Config.DefaultFloat(25)
+        public float timeLimitMs;
+
+        public long timeLimitNanos() {
+            return (long) (timeLimitMs * 1_000_000);
+        }
     }
 }

--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -1,5 +1,6 @@
 package serverutils.handlers;
 
+import static serverutils.ServerUtilitiesConfig.pregen;
 import static serverutils.ServerUtilitiesNotifications.PLAYER_AFK;
 
 import java.util.Collections;
@@ -235,7 +236,7 @@ public class ServerUtilitiesServerEventHandler {
             }
 
             if (ChunkLoaderManager.instance.isGenerating()) {
-                ChunkLoaderManager.instance.queueChunks(1);
+                ChunkLoaderManager.instance.queueChunks(pregen.chunksPerTick);
             }
         }
     }

--- a/src/main/java/serverutils/pregenerator/ChunkLoaderManager.java
+++ b/src/main/java/serverutils/pregenerator/ChunkLoaderManager.java
@@ -1,6 +1,8 @@
 package serverutils.pregenerator;
 
 import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.pack;
+import static java.lang.System.nanoTime;
+import static serverutils.ServerUtilitiesConfig.pregen;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -148,13 +150,15 @@ public class ChunkLoaderManager {
     }
 
     public void queueChunks(int numChunksToQueue) {
+        final long startTime = nanoTime();
         for (int i = 0; i < numChunksToQueue; i++) {
-            if (!chunksToLoad.isEmpty()) {
-                loader.processLoadChunk(this.serverType, this.dimensionID, chunksToLoad.dequeueLastLong());
-            } else {
+            if (chunksToLoad.isEmpty()) {
                 fileManager.closeAndRemoveAllFiles();
                 isGenerating = false;
-            }
+                break;
+            } else if ((nanoTime() - startTime) >= pregen.timeLimitNanos()) break;
+
+            loader.processLoadChunk(this.serverType, this.dimensionID, chunksToLoad.dequeueLastLong());
         }
     }
 


### PR DESCRIPTION
I'm not sure if the config is in the correct location, but otherwise this works. With this, it limits both by chunks/tick and by MSPT - if either limit is exceeded it pauses pregeneration and continues to the next tick.