### PR TITLE
Fix WorldServer memory leak

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesCommon.java
+++ b/src/main/java/serverutils/ServerUtilitiesCommon.java
@@ -250,8 +250,6 @@ public class ServerUtilitiesCommon {
 
     public void onServerAboutToStart(FMLServerAboutToStartEvent event) {
         Universe.onServerAboutToStart(event);
-        MinecraftForge.EVENT_BUS.register(Universe.get());
-        FMLCommonHandler.instance().bus().register(Universe.get());
     }
 
     public void onServerStarting(FMLServerStartingEvent event) {
@@ -268,12 +266,8 @@ public class ServerUtilitiesCommon {
     }
 
     public void onServerStopping(FMLServerStoppingEvent event) {
-        // Save the universe since onServerStopping clears the instance variable
-        Universe oldUniverse = Universe.get();
         Universe.onServerStopping(event);
         Aurora.stop();
-        MinecraftForge.EVENT_BUS.unregister(oldUniverse);
-        FMLCommonHandler.instance().bus().unregister(oldUniverse);
     }
 
     public void registerTasks() {


### PR DESCRIPTION
Turns out when you unregister a forge event class instance, that class instance is still referenced in forge's event system thus not getting garbage collected.

So I manually cleaned all the fields to fix the memory leak.