### PR TITLE
[Bug Fix] Ensure top panel buttons are refreshed when NBT structure changes

### DIFF
--- a/src/main/java/serverutils/client/gui/GuiEditNBT.java
+++ b/src/main/java/serverutils/client/gui/GuiEditNBT.java
@@ -623,6 +623,8 @@ public class GuiEditNBT extends GuiBase {
                         nbtMap.setTag(value.getString(), supplier.get());
                         selected.updateChildren(false);
                         panelNbt.refreshWidgets();
+                        panelTopLeft.refreshWidgets();
+                        panelTopRight.refreshWidgets();
                     }
 
                     GuiEditNBT.this.openGui();
@@ -631,6 +633,8 @@ public class GuiEditNBT extends GuiBase {
                 nbtCollection.setTag("-1", supplier.get());
                 selected.updateChildren(false);
                 panelNbt.refreshWidgets();
+                panelTopLeft.refreshWidgets();
+                panelTopRight.refreshWidgets();
             }
         }) {
 
@@ -667,6 +671,7 @@ public class GuiEditNBT extends GuiBase {
                                         selected = selected.parent;
                                         panelNbt.refreshWidgets();
                                         panelTopLeft.refreshWidgets();
+                                        panelTopRight.refreshWidgets();
                                     }
                                 }));
 
@@ -695,6 +700,8 @@ public class GuiEditNBT extends GuiBase {
                                                             parent.updateChildren(false);
                                                             selected = parent.children.get(s);
                                                             panelNbt.refreshWidgets();
+                                                            panelTopLeft.refreshWidgets();
+                                                            panelTopRight.refreshWidgets();
                                                         }
                                                     }
 


### PR DESCRIPTION
When editing NBT data via the `/nbtedit` command, the top left panel buttons do not dynamically update. This is confusing. Always ensure button state is up to date by refreshing the panel widgets after updating the NBT structure in any way.