### PR TITLE
[Bug Fix] Fix `canCreateNew` check in `ButtonNBTList` in `GuiEditNBT`.

### DIFF
--- a/src/main/java/serverutils/client/gui/GuiEditNBT.java
+++ b/src/main/java/serverutils/client/gui/GuiEditNBT.java
@@ -478,7 +478,7 @@ public class GuiEditNBT extends GuiBase {
 
         @Override
         public boolean canCreateNew(int id) {
-            return list.tagCount() == 0 || list.getId() == id;
+            return list.tagCount() == 0 || list.tagList.get(0).getId() == id;
         }
 
         @Override


### PR DESCRIPTION
The check was previously checking against `list.getId()` which always returns `9`, or the constant ID for a NBT list. The correct logic is to check if the list is empty, in which case permit any NBT type, or check the type of the first item in the list and then permit only that type.