### PR TITLE
fix: Team activity updates not being saved

### DIFF
--- a/src/main/java/serverutils/lib/data/ForgeTeam.java
+++ b/src/main/java/serverutils/lib/data/ForgeTeam.java
@@ -668,12 +668,14 @@ public class ForgeTeam extends FinalIDObject implements INBTSerializable<NBTTagC
                 latestActivity = Math.max(player.getLastTimeSeen(), latestActivity);
             }
             lastActivity = System.currentTimeMillis() - Ticks.get(universe.ticks.ticks() - latestActivity).millis();
+            markDirty();
         }
         return lastActivity;
     }
 
     public void refreshActivity() {
         lastActivity = System.currentTimeMillis();
+        markDirty();
     }
 
     public Ticks getHighestTimer(String node) {


### PR DESCRIPTION
Unless I am missing something, updating activity time on player login should save it to the team data file. Currently, there are 2 places where team.refreshActivity() is called. DecayTask and onPlayerLoginEvent. The first one is executed every 5 minutes and has a check for anyone being online. The second one should do it always, but since refreshActivity() doesn't call markDirty(), if player logs-in and logs out quickly, it might not be saved once server restarts.