### PR TITLE
[Feature] Implement better handling of the ray cast results in the `/nbtedit` command client-side handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 .settings
+.java-version
 /.idea/
 /.vscode/
 /run/

--- a/src/main/java/serverutils/net/MessageEditNBTRequest.java
+++ b/src/main/java/serverutils/net/MessageEditNBTRequest.java
@@ -8,7 +8,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 import serverutils.lib.client.ClientUtils;
 import serverutils.lib.net.MessageToClient;
 import serverutils.lib.net.NetworkWrapper;
-import serverutils.lib.util.StringJoiner;
 
 public class MessageEditNBTRequest extends MessageToClient {
 
@@ -28,14 +27,18 @@ public class MessageEditNBTRequest extends MessageToClient {
     @SideOnly(Side.CLIENT)
     public static void editNBT() {
         MovingObjectPosition ray = Minecraft.getMinecraft().objectMouseOver;
-
-        if (ray != null) {
-            if (ray.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
-                ClientUtils.execClientCommand(
-                        StringJoiner.with(' ').joinObjects("/nbtedit block", ray.blockX, ray.blockY, ray.blockZ));
-            } else if (ray.typeOfHit == MovingObjectPosition.MovingObjectType.ENTITY && ray.entityHit != null) {
-                ClientUtils.execClientCommand("/nbtedit entity " + ray.entityHit.getEntityId());
-            }
+        if (ray == null) {
+            return;
+        }
+        if (ray.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK
+                && Minecraft.getMinecraft().theWorld.getTileEntity(ray.blockX, ray.blockY, ray.blockZ) != null) {
+            ClientUtils.execClientCommand(String.format("/nbtedit block %d %d %d", ray.blockX, ray.blockY, ray.blockZ));
+        } else if (ray.typeOfHit == MovingObjectPosition.MovingObjectType.ENTITY && ray.entityHit != null) {
+            ClientUtils.execClientCommand(String.format("/nbtedit entity %s", ray.entityHit.getEntityId()));
+        } else if (Minecraft.getMinecraft().thePlayer.inventory.getCurrentItem() != null) {
+            ClientUtils.execClientCommand("/nbtedit item");
+        } else {
+            ClientUtils.execClientCommand("/nbtedit me");
         }
     }
 }


### PR DESCRIPTION
### Note ###

This is a recreation of #223 because I'm silly and accidentally deleted the fork the original PR was from. 😅

I have included any relevant or unresolved feedback for context.

### Original PR Description ###

The old handler would check if the hit was a block or entity (and the entity wasn't `null`) and call the appropriate commands. This, while correct, was not very intuitive for end users.

This PR changes the command behaviour to be more user friendly.

The new behaviour is as follows:

* If the hit is a block, check that the block has a valid, editable tile entity attached to it.
  * If so, proceed to issue the `/nbtedit block <BLOCK_X> <BLOCK_Y> <BLOCK_Z>` command.
* If the hit is an entity, check that the entity is valid.
  * If so, proceed to issue the `/nbtedit entity <ENTITY_ID>` command.
* If neither of the above are true, check if the player has an item in their hand.
  * If so, proceed to issue the `/nbtedit item` command.
* If none of the above are true, proceed to issue the `/nbtedit me` command.

This is far more intuitive and covers all possible cases that the ray cast can return with a valid command being issued rather than the user input simply being voided because the ray cast didn't return anything.