### PR TITLE
[Bug Fix] Fix `canCreateNew` check in `ButtonNBTList` in `GuiEditNBT`

### DIFF
--- a/src/main/java/serverutils/client/gui/GuiEditNBT.java
+++ b/src/main/java/serverutils/client/gui/GuiEditNBT.java
@@ -478,7 +478,7 @@ public class GuiEditNBT extends GuiBase {
 
         @Override
         public boolean canCreateNew(int id) {
-            return list.tagCount() == 0 || list.getId() == id;
+            return list.tagCount() == 0 || ((NBTBase) list.tagList.get(0)).getId() == id;
         }
 
         @Override


### PR DESCRIPTION
### Note ###

This is a recreation of #222 because I'm silly and accidentally deleted the fork the original PR was from. 😅

### Original PR Description ###

The check was previously checking against `list.getId()` which always returns `9`, or the constant ID for a NBT list. The correct logic is to check if the list is empty, in which case permit any NBT type, or check the type of the first item in the list and then permit only that type.

### Original Feedback "Thread" by @Taskeren ###

Comment by @Taskeren:
> I didn't not quite look into it, but there are also IntArray and ByteArray, shouldn't they be changed like this?

Response by @glektarssza:
> They might need to be changed but not in the same way.
> 
> The issue here is that creating an empty NBT list would then only let you add NBT lists as items to that newly created list due to the check mentioned in the PR description.
>
> I'll look at the other two checks you mentioned after work to double check them!

Second response by @glektarssza:
> Finally got around to checking on this (work was hell this last bit...🔥).
> 
> So for the `IntArray`:
> 
> ```java
> @Override
> public boolean canCreateNew(int id) {
>     return id == Constants.NBT.TAG_INT;
> }
> ```
> 
> It checks if you're adding an `Int` NBT tag. Which makes sense.
> 
> And similarly for `ByteArray`:
> 
> ```java
> @Override
> public boolean canCreateNew(int id) {
>     return id == Constants.NBT.TAG_BYTE;
> }
> ```
> 
> So yes, this is the only change required out of these three.