### PR TITLE
feat: new backup settings for claimed chunks only that saves the entire region file

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -335,6 +335,13 @@ public class ServerUtilitiesConfig {
                 Backups will be much faster and smaller, but any unclaimed chunk will be unrecoverable.""")
         @Config.DefaultBoolean(false)
         public boolean only_backup_claimed_chunks;
+
+        @Config.Comment("""
+                Backup entire regions that contain at least one claimed chunk.
+                This backs up complete .mca files instead of reconstructing temporary files with only claimed chunks.
+                Requires only_backup_claimed_chunks to be enabled.""")
+        @Config.DefaultBoolean(false)
+        public boolean backup_entire_regions_with_claims;
     }
 
     public static class Login {


### PR DESCRIPTION
Config setting is self explanatory.
Prevents blocks, structures and their loot in the same region as claimed chunks from re-generating, at the cost of a slightly larger backup file.