### PR TITLE
[Feature] Player log in MOTD reload via `/reload` command (take 2!)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ whitelist.json
 src/main/resources/mixins.*([!.]).json
 *.bat
 *.DS_Store
+.env*
 !gradlew.bat
 .factorypath
 addon.local.gradle

--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -413,7 +413,7 @@ public class ServerUtilitiesConfig {
                         List<String> rawLines = Files.readAllLines(motdF);
                         List<String> lines = rawLines.stream().filter((line) -> !line.startsWith(";"))
                                 .collect(Collectors.toList());
-                        if (rawLines.isEmpty()) {
+                        if (rawLines.isEmpty() && motd.length != 0) {
                             ServerUtilities.LOGGER
                                     .warn("Failed to read player login MOTD from external file \"{}\"!", motdFile);
                             ServerUtilities.LOGGER

--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -1,6 +1,11 @@
 package serverutils;
 
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -361,9 +366,13 @@ public class ServerUtilitiesConfig {
         @Config.DefaultBoolean(false)
         public boolean enable_starting_items;
 
-        @Config.Comment("Message of the day. This will be displayed when player joins the server.")
-        @Config.DefaultStringList("Hello player!")
+        @Config.Comment("Message of the day. This will be displayed when player joins the server. Overrides the \"motdFile\" if it contains any values other than empty strings.")
+        @Config.DefaultStringList({})
         public String[] motd;
+
+        @Config.Comment("Message of the day file. This contents of this file will be displayed when player joins the server.")
+        @Config.DefaultString("")
+        public String motdFile;
 
         @Config.Comment("Items to give player when they first join the server.\nFormat: '{id:\"ID\",Count:X,Damage:X,tag:{}}', Use /print_item to get NBT of item in your hand.")
         @Config.DefaultStringList({
@@ -376,15 +385,62 @@ public class ServerUtilitiesConfig {
         @Config.Ignore
         private List<ItemStack> startingItems = null;
 
+        /**
+         * Reload the player login message of the day chat components.
+         */
+        public void reloadMOTD() {
+            ServerUtilities.LOGGER.info("Reloading player login MOTD...");
+
+            motdComponents = new ArrayList<IChatComponent>();
+
+            if (!enable_motd) {
+                ServerUtilities.LOGGER.debug("Player login MOTD is not enabled, doing nothing!");
+                return;
+            } else {
+                ServerUtilities.LOGGER.debug("Player login MOTD is enabled, proceeding!");
+            }
+            boolean hasMotdConfig = !Arrays.stream(motd).allMatch(String::isEmpty);
+            if (!hasMotdConfig && motdFile != null && !motdFile.isEmpty()) {
+                ServerUtilities.LOGGER
+                        .debug("Player login MOTD from external file is enabled, loading \"{}\"!", motdFile);
+                Path motdF = FileSystems.getDefault().getPath(motdFile);
+                if (Files.exists(motdF)) {
+                    try {
+                        motd = Files.readAllLines(motdF).toArray(motd);
+                        hasMotdConfig = true;
+                    } catch (IOException e) {
+                        ServerUtilities.LOGGER
+                                .warn("Failed to read player login MOTD from external file \"{}\"!", motdFile);
+                        ServerUtilities.LOGGER.warn("Encountered exception while reading: {}", e);
+                    }
+                } else {
+                    ServerUtilities.LOGGER.warn(
+                            "Player login MOTD was asked to be loaded from external file \"{}\" but it was not present on disk!",
+                            motdFile);
+                    ServerUtilities.LOGGER.warn("Falling back to the \"motd\" configuration value!");
+                }
+            }
+            if (hasMotdConfig) {
+                for (String s : motd) {
+                    motdComponents.add(ForgeHooks.newChatWithLinks(s));
+                }
+            }
+            ServerUtilities.LOGGER.info("Successfully reloaded player login MOTD");
+            if (hasMotdConfig && motdFile != null && !motdFile.isEmpty()) {
+                ServerUtilities.LOGGER.info("Player login MOTD has been sourced from external file \"{}\"", motdFile);
+            } else if (hasMotdConfig) {
+                ServerUtilities.LOGGER.info("Player login MOTD has been sourced from internal configuration");
+            }
+        }
+
+        /**
+         * Get the player login message of the day chat components.
+         *
+         * @return The player login message of the day chat components.
+         */
         public List<IChatComponent> getMOTD() {
             if (motdComponents == null) {
-                motdComponents = new ArrayList<>();
-
-                if (enable_motd) {
-                    for (String s : motd) {
-                        motdComponents.add(ForgeHooks.newChatWithLinks(s));
-                    }
-                }
+                reloadMOTD();
             }
 
             return motdComponents;

--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -387,15 +387,17 @@ public class ServerUtilitiesConfig {
 
         /**
          * Reload the player login message of the day chat components.
+         *
+         * @return {@code true} if the resources were reloaded, {@code false} otherwise.
          */
-        public void reloadMOTD() {
+        public boolean reloadMOTD() {
             ServerUtilities.LOGGER.info("Reloading player login MOTD...");
 
             motdComponents = new ArrayList<IChatComponent>();
 
             if (!enable_motd) {
                 ServerUtilities.LOGGER.debug("Player login MOTD is not enabled, doing nothing!");
-                return;
+                return false;
             } else {
                 ServerUtilities.LOGGER.debug("Player login MOTD is enabled, proceeding!");
             }
@@ -431,6 +433,7 @@ public class ServerUtilitiesConfig {
             } else if (hasMotdConfig) {
                 ServerUtilities.LOGGER.info("Player login MOTD has been sourced from internal configuration");
             }
+            return true;
         }
 
         /**
@@ -440,7 +443,10 @@ public class ServerUtilitiesConfig {
          */
         public List<IChatComponent> getMOTD() {
             if (motdComponents == null) {
-                reloadMOTD();
+                if (!reloadMOTD()) {
+                    // -- Reload failed, parachute!
+                    motdComponents = new ArrayList<IChatComponent>();
+                }
             }
 
             return motdComponents;

--- a/src/main/java/serverutils/handlers/ServerUtilitiesRegistryEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesRegistryEventHandler.java
@@ -36,6 +36,9 @@ public class ServerUtilitiesRegistryEventHandler {
         registry.registerServerReloadHandler(
                 new ResourceLocation(ServerUtilities.MOD_ID, "ranks"),
                 reloadEvent -> Ranks.INSTANCE.reload());
+        registry.registerServerReloadHandler(
+                new ResourceLocation(ServerUtilities.MOD_ID, "login:motd"),
+                reloadEvent -> ServerUtilitiesConfig.login.reloadMOTD());
 
         registry.registerSyncData(ServerUtilities.MOD_ID, new ServerUtilitiesSyncData());
 


### PR DESCRIPTION
Reworked version of #247 to actually address the feature suggestion in #244.

Since the normal player login MOTD is handled via `GTNHLib` I added a new setting which provides a path on disk to read the MOTD from. This way it can be reloaded via the `/reload` command since it seems `GTNHLib`'s configuration system does not support reloading at runtime.

The format of this file is very simple. Each line is a line to be displayed to players and is processed as a chat component (and all the normal processing that implies such as color codes). Lines starting in a semi-colon (<kbd>;</kbd>) will be treated as a comment and not processed at all.

There's some fallback logic in the code so that if, for example, the file exists but is blank it will be populated with the contents of the current `login.motd` values.

Making this a draft PR as it needs some cleanup and testing before being ready for full review but wanted to get feedback early.