### PR TITLE
Add ability to flip specified game rules when server is empty

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -616,6 +616,19 @@ public class ServerUtilitiesConfig {
         @Config.DefaultStringList({ "AMBIENT", "WATER_CREATURE", "MOB", "ANIMAL" })
         public String[] mobTypesToBlock;
 
+        @Config.Comment("Enable flipping specific game rules when server is empty.")
+        @Config.DefaultBoolean(false)
+        public boolean enable_flip_game_rules_when_empty;
+
+        @Config.Comment("Flip specific game rules when server is empty for x seconds.")
+        @Config.DefaultInt(60)
+        @Config.RangeInt(min = 0, max = 86400)
+        public int flip_game_rules_when_empty_seconds;
+
+        @Config.Comment("Which game rules to flip when server is empty. Example: doDaylightCycle, doWeatherCycle , ...")
+        @Config.DefaultStringList({ "" })
+        public String[] flip_game_rules_when_empty_rules;
+
         @Config.Ignore
         private List<DisabledItem> disabledItems = null;
 

--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -510,6 +510,7 @@ public class ServerUtilitiesConfig {
             public String[] flip_game_rules_when_empty_rules;
         }
 
+        @Config.Name("flip_game_rules_when_empty")
         public final RulesFlip flip = new RulesFlip();
 
         @Config.Comment("Enables chunk claiming.")

--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -481,6 +481,24 @@ public class ServerUtilitiesConfig {
 
         public final WorldLogging logging = new WorldLogging();
 
+        public static class RulesFlip {
+
+            @Config.Comment("Enable flipping specific game rules when server is empty.")
+            @Config.DefaultBoolean(false)
+            public boolean enable_flip_game_rules_when_empty;
+
+            @Config.Comment("Flip specific game rules when server is empty for x seconds.")
+            @Config.DefaultInt(60)
+            @Config.RangeInt(min = 0, max = 86400)
+            public int flip_game_rules_when_empty_seconds;
+
+            @Config.Comment("Which game rules to flip when server is empty. Example: doDaylightCycle, doWeatherCycle , ...")
+            @Config.DefaultStringList({ "" })
+            public String[] flip_game_rules_when_empty_rules;
+        }
+
+        public final RulesFlip flip = new RulesFlip();
+
         @Config.Comment("Enables chunk claiming.")
         @Config.DefaultBoolean(true)
         public boolean chunk_claiming;
@@ -615,19 +633,6 @@ public class ServerUtilitiesConfig {
                 """)
         @Config.DefaultStringList({ "AMBIENT", "WATER_CREATURE", "MOB", "ANIMAL" })
         public String[] mobTypesToBlock;
-
-        @Config.Comment("Enable flipping specific game rules when server is empty.")
-        @Config.DefaultBoolean(false)
-        public boolean enable_flip_game_rules_when_empty;
-
-        @Config.Comment("Flip specific game rules when server is empty for x seconds.")
-        @Config.DefaultInt(60)
-        @Config.RangeInt(min = 0, max = 86400)
-        public int flip_game_rules_when_empty_seconds;
-
-        @Config.Comment("Which game rules to flip when server is empty. Example: doDaylightCycle, doWeatherCycle , ...")
-        @Config.DefaultStringList({ "" })
-        public String[] flip_game_rules_when_empty_rules;
 
         @Config.Ignore
         private List<DisabledItem> disabledItems = null;

--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -483,7 +483,9 @@ public class ServerUtilitiesConfig {
 
         public static class RulesFlip {
 
-            @Config.Comment("Enable flipping specific game rules when server is empty.")
+            @Config.Comment("""
+                    Enable flipping specific game rules when server is empty.
+                    Note: Flip state is stored on restart. If you disable it probably first stop the server in a unflipped state.""")
             @Config.DefaultBoolean(false)
             public boolean enable_flip_game_rules_when_empty;
 
@@ -492,7 +494,9 @@ public class ServerUtilitiesConfig {
             @Config.RangeInt(min = 0, max = 86400)
             public int flip_game_rules_when_empty_seconds;
 
-            @Config.Comment("Which game rules to flip when server is empty. Example: doDaylightCycle, doWeatherCycle , ...")
+            @Config.Comment("""
+                    Which game rules to flip when server is empty.
+                    Example: doDaylightCycle, doWeatherCycle , ...""")
             @Config.DefaultStringList({ "" })
             public String[] flip_game_rules_when_empty_rules;
         }

--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -161,6 +161,10 @@ public class ServerUtilitiesServerEventHandler {
         if (flip) {
             for (String rule : rulesToFlip) {
                 if (rule == null || rule.isEmpty()) continue;
+                if (!rules.hasRule(rule)) {
+                    ServerUtilities.LOGGER.warn("[Rules Flip] Game rule \"{}\" does not exist, skipping.", rule);
+                    continue;
+                }
                 boolean ruleValue = rules.getGameRuleBooleanValue(rule);
                 universe.flippedRulesSaveState.put(rule, String.valueOf(ruleValue));
                 rules.setOrCreateGameRule(rule, String.valueOf(!ruleValue));

--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -14,6 +14,7 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
+import net.minecraft.world.GameRules;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.event.ServerChatEvent;
 import net.minecraftforge.event.world.WorldEvent;
@@ -55,6 +56,8 @@ public class ServerUtilitiesServerEventHandler {
     private static final String BOLD_REPLACE = "&l$1&l";
     private static final Pattern ITALIC_PATTERN = Pattern.compile("\\*(.+?)\\*|_(.+?)_");
     private static final String ITALIC_REPLACE = "&o$1&o";
+
+    private static int emptyTicks = 0;
 
     @SubscribeEvent
     public static void loadWorldEvent(WorldEvent.Load event) {
@@ -150,6 +153,33 @@ public class ServerUtilitiesServerEventHandler {
         event.component = new ChatComponentTranslation("serverutilities.chat.format", main);
     }
 
+    public static void flipGameRules(Universe universe, boolean flip) {
+        String[] rulesToFlip = ServerUtilitiesConfig.world.flip_game_rules_when_empty_rules;
+
+        GameRules rules = universe.world.getGameRules();
+
+        if (flip) {
+            for (String rule : rulesToFlip) {
+                if (rule == null || rule.isEmpty()) continue;
+                boolean ruleValue = rules.getGameRuleBooleanValue(rule);
+                universe.flippedRulesSaveState.put(rule, String.valueOf(ruleValue));
+                rules.setOrCreateGameRule(rule, String.valueOf(!ruleValue));
+                ServerUtilities.LOGGER
+                        .info("[Rules Flip] Changed game rule \"{}\" from {} to {}.", rule, ruleValue, !ruleValue);
+            }
+        } else {
+            for (String rule : rulesToFlip) {
+                if (rule == null || rule.isEmpty()) continue;
+                String savedValue = universe.flippedRulesSaveState.get(rule);
+                rules.setOrCreateGameRule(rule, savedValue);
+                ServerUtilities.LOGGER
+                        .info("[Rules Flip] Restored game rule \"{}\" to {} from saved state.", rule, savedValue);
+            }
+            universe.flippedRulesSaveState.clear();
+        }
+        universe.markDirty();
+    }
+
     @SubscribeEvent
     public static void onServerTick(TickEvent.ServerTickEvent event) {
         if (!Universe.loaded()) {
@@ -231,6 +261,33 @@ public class ServerUtilitiesServerEventHandler {
 
             if (ChunkLoaderManager.instance.isGenerating()) {
                 ChunkLoaderManager.instance.queueChunks(pregen.chunksPerTick);
+            }
+
+            if (ServerUtilitiesConfig.world.enable_flip_game_rules_when_empty) {
+                boolean serverHasPlayer = false;
+                for (EntityPlayerMP player : universe.server.getConfigurationManager().playerEntityList) {
+                    if (!ServerUtils.isFake(player)) {
+                        serverHasPlayer = true;
+                        break;
+                    }
+                }
+
+                if (serverHasPlayer) {
+                    emptyTicks = 0;
+                    if (universe.gameRulesFlipped) {
+                        universe.gameRulesFlipped = false;
+                        flipGameRules(universe, false);
+                    }
+                } else {
+                    int beforeRulesFlipTick = ServerUtilitiesConfig.world.flip_game_rules_when_empty_seconds * 20;
+                    if (!universe.gameRulesFlipped) {
+                        emptyTicks++;
+                        if (emptyTicks >= beforeRulesFlipTick) {
+                            universe.gameRulesFlipped = true;
+                            flipGameRules(universe, true);
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -154,7 +154,7 @@ public class ServerUtilitiesServerEventHandler {
     }
 
     public static void flipGameRules(Universe universe, boolean flip) {
-        String[] rulesToFlip = ServerUtilitiesConfig.world.flip_game_rules_when_empty_rules;
+        String[] rulesToFlip = ServerUtilitiesConfig.world.flip.flip_game_rules_when_empty_rules;
 
         GameRules rules = universe.world.getGameRules();
 
@@ -263,7 +263,7 @@ public class ServerUtilitiesServerEventHandler {
                 ChunkLoaderManager.instance.queueChunks(pregen.chunksPerTick);
             }
 
-            if (ServerUtilitiesConfig.world.enable_flip_game_rules_when_empty) {
+            if (ServerUtilitiesConfig.world.flip.enable_flip_game_rules_when_empty) {
                 boolean serverHasPlayer = false;
                 for (EntityPlayerMP player : universe.server.getConfigurationManager().playerEntityList) {
                     if (!ServerUtils.isFake(player)) {
@@ -279,7 +279,7 @@ public class ServerUtilitiesServerEventHandler {
                         flipGameRules(universe, false);
                     }
                 } else {
-                    int beforeRulesFlipTick = ServerUtilitiesConfig.world.flip_game_rules_when_empty_seconds * 20;
+                    int beforeRulesFlipTick = ServerUtilitiesConfig.world.flip.flip_game_rules_when_empty_seconds * 20;
                     if (!universe.gameRulesFlipped) {
                         emptyTicks++;
                         if (emptyTicks >= beforeRulesFlipTick) {

--- a/src/main/java/serverutils/lib/data/Universe.java
+++ b/src/main/java/serverutils/lib/data/Universe.java
@@ -212,6 +212,8 @@ public class Universe {
     private boolean prevCheats = false;
     public File dataFolder;
     public File latModFolder;
+    public boolean gameRulesFlipped;
+    public final Map<String, String> flippedRulesSaveState;
 
     public Universe(MinecraftServer s) {
         server = s;
@@ -226,6 +228,8 @@ public class Universe {
         checkSaving = true;
         taskList = new ArrayList<>();
         taskQueue = new ArrayList<>();
+        gameRulesFlipped = false;
+        flippedRulesSaveState = new HashMap<>();
     }
 
     public void markDirty() {
@@ -405,6 +409,15 @@ public class Universe {
 
         fakePlayerTeam.owner = fakePlayer;
 
+        if (universeData.hasKey("GameRulesState")) {
+            NBTTagCompound gameRulesState = universeData.getCompoundTag("GameRulesState");
+            gameRulesFlipped = gameRulesState.getBoolean("Flipped");
+            NBTTagCompound savedRules = gameRulesState.getCompoundTag("SavedRules");
+            for (String key : NBTUtils.getKeySet(savedRules)) {
+                flippedRulesSaveState.put(key, savedRules.getString(key));
+            }
+        }
+
         new UniverseLoadedEvent.Post(this, data).post();
 
         if (shouldLoadLatmod()) {
@@ -433,6 +446,14 @@ public class Universe {
             universeData.setString("UUID", StringUtils.fromUUID(getUUID()));
             universeData.setTag("FakePlayer", fakePlayer.serializeNBT());
             universeData.setTag("FakeTeam", fakePlayerTeam.serializeNBT());
+            NBTTagCompound gameRulesState = new NBTTagCompound();
+            gameRulesState.setBoolean("Flipped", gameRulesFlipped);
+            NBTTagCompound savedRules = new NBTTagCompound();
+            for (Map.Entry<String, String> entry : flippedRulesSaveState.entrySet()) {
+                savedRules.setString(entry.getKey(), entry.getValue());
+            }
+            gameRulesState.setTag("SavedRules", savedRules);
+            universeData.setTag("GameRulesState", gameRulesState);
             NBTUtils.writeNBTSafe(new File(dataFolder, "universe.dat"), universeData);
             needsSaving = false;
         }

--- a/src/main/java/serverutils/lib/util/NBTUtils.java
+++ b/src/main/java/serverutils/lib/util/NBTUtils.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -210,5 +211,9 @@ public class NBTUtils {
 
     public static boolean getBooleanOrTrue(NBTTagCompound nbt, String key) {
         return !nbt.hasKey(key) || nbt.getBoolean(key);
+    }
+
+    public static Set<String> getKeySet(NBTTagCompound nbt) {
+        return nbt.func_150296_c();
     }
 }


### PR DESCRIPTION
This PR started with me wanting to be able to turn doDaylightCycle off when my server is empty, so that day counter stop increasing too fast.
After talking about it in voice chat I was told SU would be a good place for this but to instead make it able to flip any game rules like mob spawning or something added by another mod.


This introduces 3 new configs regarding this:
(this is disabled by default, just showing an example)
<img width="967" height="270" alt="image" src="https://github.com/user-attachments/assets/8b71079d-7807-4487-8504-79fd30622bde" />

Changes made are stored into the Server Utilities universe.dat file to avoid double flipping
<img width="335" height="138" alt="image" src="https://github.com/user-attachments/assets/3280835b-0246-4a8b-8516-ae11c613126c" />

I'm also logging at info level for the purpose of keeping a record in case something goes wrong or is misconfigured.