### PR TITLE
Add command permissions support for brigadier commands

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesCommon.java
+++ b/src/main/java/serverutils/ServerUtilitiesCommon.java
@@ -11,11 +11,16 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.util.IChatComponent;
 import net.minecraftforge.common.ForgeChunkManager;
 import net.minecraftforge.common.MinecraftForge;
 
+import com.gtnewhorizon.gtnhlib.brigadier.BrigadierApi;
 import com.gtnewhorizon.gtnhlib.config.ConfigurationManager;
+import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
@@ -40,6 +45,8 @@ import serverutils.lib.net.MessageToClient;
 import serverutils.lib.util.ServerUtils;
 import serverutils.lib.util.permission.PermissionAPI;
 import serverutils.net.ServerUtilitiesNetHandler;
+import serverutils.ranks.ICommandWithPermission;
+import serverutils.ranks.Rank;
 import serverutils.ranks.ServerUtilitiesPermissionHandler;
 import serverutils.task.CleanupTask;
 import serverutils.task.DecayTask;
@@ -123,6 +130,30 @@ public class ServerUtilitiesCommon {
     public void onServerStarted(FMLServerStartedEvent event) {
         Universe.onServerStarted(event);
         registerTasks();
+
+        if (ranks.enabled && ranks.command_permissions) {
+            for (CommandNode<?> node : BrigadierApi.getCommandDispatcher().getRoot().getChildren()) {
+                if (node instanceof LiteralCommandNode<?>literalNode) {
+                    registerBrigadierCommands(literalNode, (ICommandWithPermission) literalNode, null);
+                }
+            }
+        }
+    }
+
+    private static void registerBrigadierCommands(LiteralCommandNode<?> literalNode, ICommandWithPermission cmdPerm,
+            @Nullable String parentNode) {
+        String node = parentNode == null
+                ? Rank.NODE_COMMAND + '.' + cmdPerm.serverutilities$getModId() + "." + literalNode.getLiteral()
+                : parentNode + "." + literalNode.getLiteral();
+
+        cmdPerm.serverutilities$setPermissionNode(node);
+        cmdPerm.serverUtilities$registerPermissions();
+
+        for (CommandNode<?> child : literalNode.getChildren()) {
+            if (child instanceof LiteralCommandNode<?>childLiteral) {
+                registerBrigadierCommands(childLiteral, (ICommandWithPermission) childLiteral, node);
+            }
+        }
     }
 
     public void onServerStopping(FMLServerStoppingEvent event) {

--- a/src/main/java/serverutils/ServerUtilitiesCommon.java
+++ b/src/main/java/serverutils/ServerUtilitiesCommon.java
@@ -146,7 +146,7 @@ public class ServerUtilitiesCommon {
                 ? Rank.NODE_COMMAND + '.' + cmdPerm.serverutilities$getModId() + "." + literalNode.getLiteral()
                 : parentNode + "." + literalNode.getLiteral();
 
-        cmdPerm.serverutilities$setPermissionNode(node);
+        cmdPerm.serverutilities$setPermissionNode(node.toLowerCase());
         cmdPerm.serverUtilities$registerPermissions();
 
         for (CommandNode<?> child : literalNode.getChildren()) {

--- a/src/main/java/serverutils/command/CmdDumpPermissions.java
+++ b/src/main/java/serverutils/command/CmdDumpPermissions.java
@@ -8,8 +8,11 @@ import java.util.List;
 import net.minecraft.command.ICommand;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.IChatComponent;
+
+import com.mojang.brigadier.tree.CommandNode;
 
 import serverutils.ServerUtilities;
 import serverutils.ServerUtilitiesPermissions;
@@ -149,20 +152,29 @@ public class CmdDumpPermissions extends CmdBase {
         commandList.add(Arrays.asList("Node", "Command", "Default Permission", "Usage"));
         commandList.add(Arrays.asList(EMPTY_ROW));
 
-        for (ICommand command : CommandUtils.getAllCommands(sender)) {
-            if (command instanceof ICommandWithPermission cmd) {
-                String node = cmd.serverutilities$getPermissionNode();
-                DefaultPermissionLevel defaultPermissionLevel = DefaultPermissionHandler.INSTANCE
-                        .getDefaultPermissionLevel(node);
-                IChatComponent usage = CommandUtils.getTranslatedUsage(command, sender);
+        for (ICommandWithPermission command : CommandUtils.getPermissionCommands()) {
+            String node = command.serverutilities$getPermissionNode();
+            DefaultPermissionLevel defaultPermissionLevel = DefaultPermissionHandler.INSTANCE
+                    .getDefaultPermissionLevel(node);
 
-                commandList.add(
-                        Arrays.asList(
-                                node,
-                                "/" + command.getCommandName(),
-                                defaultPermissionLevel.name(),
-                                usage.getUnformattedText()));
+            IChatComponent usage;
+            if (command instanceof ICommand cmd) {
+                usage = CommandUtils.getTranslatedUsage(cmd, sender);
+            } else if (command instanceof CommandNode<?>cmdNode) {
+                usage = new ChatComponentText(cmdNode.getUsageText());
+            } else {
+                usage = new ChatComponentText("");
             }
+
+            String cmdName = null;
+            if (command instanceof ICommand cmd) {
+                cmdName = cmd.getCommandName();
+            } else if (command instanceof CommandNode<?>cmdNode) {
+                cmdName = cmdNode.getName();
+            }
+
+            commandList
+                    .add(Arrays.asList(node, "/" + cmdName, defaultPermissionLevel.name(), usage.getUnformattedText()));
         }
 
         int[] cmdMaxLength = new int[4];

--- a/src/main/java/serverutils/core/ServerUtilitiesCore.java
+++ b/src/main/java/serverutils/core/ServerUtilitiesCore.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.gtnewhorizon.gtnhlib.config.ConfigException;
+import net.minecraft.launchwrapper.Launch;
+import net.minecraft.launchwrapper.LaunchClassLoader;
+
 import com.gtnewhorizon.gtnhlib.config.ConfigurationManager;
 import com.gtnewhorizon.gtnhmixins.IEarlyMixinLoader;
 import com.gtnewhorizon.gtnhmixins.builders.IMixins;
@@ -19,11 +21,18 @@ public class ServerUtilitiesCore implements IFMLLoadingPlugin, IEarlyMixinLoader
 
     static {
         try {
-            ConfigurationManager.registerConfig(ServerUtilitiesConfig.class);
-            ConfigurationManager.registerConfig(AuroraConfig.class);
-        } catch (ConfigException e) {
+            var cleF = LaunchClassLoader.class.getDeclaredField("classLoaderExceptions");
+            cleF.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            var cle = (Set<String>) cleF.get(Launch.classLoader);
+            // for Brigadier
+            cle.remove("com.mojang.");
+        } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
+
+        ConfigurationManager.registerConfig(ServerUtilitiesConfig.class);
+        ConfigurationManager.registerConfig(AuroraConfig.class);
     }
 
     @Override

--- a/src/main/java/serverutils/lib/command/CommandUtils.java
+++ b/src/main/java/serverutils/lib/command/CommandUtils.java
@@ -20,7 +20,6 @@ import net.minecraft.util.IChatComponent;
 import net.minecraftforge.common.DimensionManager;
 
 import com.gtnewhorizon.gtnhlib.brigadier.BrigadierApi;
-import com.mojang.brigadier.tree.ArgumentCommandNode;
 import com.mojang.brigadier.tree.CommandNode;
 
 import serverutils.ServerUtilities;
@@ -204,10 +203,10 @@ public class CommandUtils {
             }
         }
 
-        if (command instanceof CommandNode<?>node && !(node instanceof ArgumentCommandNode)) {
+        if (command instanceof CommandNode<?>node) {
             for (CommandNode<?> child : node.getChildren()) {
-                if (!(child instanceof ArgumentCommandNode)) {
-                    addCommand(list, (ICommandWithPermission) child);
+                if (child instanceof ICommandWithPermission cmdPerm) {
+                    addCommand(list, cmdPerm);
                 }
             }
         }

--- a/src/main/java/serverutils/lib/command/CommandUtils.java
+++ b/src/main/java/serverutils/lib/command/CommandUtils.java
@@ -19,6 +19,10 @@ import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.IChatComponent;
 import net.minecraftforge.common.DimensionManager;
 
+import com.gtnewhorizon.gtnhlib.brigadier.BrigadierApi;
+import com.mojang.brigadier.tree.ArgumentCommandNode;
+import com.mojang.brigadier.tree.CommandNode;
+
 import serverutils.ServerUtilities;
 import serverutils.ServerUtilitiesConfig;
 import serverutils.lib.data.ForgePlayer;
@@ -180,14 +184,32 @@ public class CommandUtils {
         if (!Ranks.isActive() || !ServerUtilitiesConfig.ranks.command_permissions) return Collections.emptyList();
         List<ICommandWithPermission> list = new ArrayList<>();
         for (ICommand cmd : ServerUtils.getServer().getCommandManager().getCommands().values()) {
-            ICommandWithPermission command = (ICommandWithPermission) cmd;
-            if (command instanceof CommandTreeBase tree) {
-                for (ICommand child : tree.getSubCommands()) {
-                    list.add((ICommandWithPermission) child);
+            addCommand(list, (ICommandWithPermission) cmd);
+        }
+
+        BrigadierApi.getCommandDispatcher().getRoot().getChildren().forEach((command) -> {
+            if (command instanceof ICommandWithPermission cmd) {
+                addCommand(list, cmd);
+            }
+        });
+        return list;
+    }
+
+    private static void addCommand(List<ICommandWithPermission> list, ICommandWithPermission command) {
+        list.add(command);
+
+        if (command instanceof CommandTreeBase tree) {
+            for (ICommand child : tree.getSubCommands()) {
+                list.add((ICommandWithPermission) child);
+            }
+        }
+
+        if (command instanceof CommandNode<?>node && !(node instanceof ArgumentCommandNode)) {
+            for (CommandNode<?> child : node.getChildren()) {
+                if (!(child instanceof ArgumentCommandNode)) {
+                    addCommand(list, (ICommandWithPermission) child);
                 }
             }
-            list.add(command);
         }
-        return list;
     }
 }

--- a/src/main/java/serverutils/mixin/Mixins.java
+++ b/src/main/java/serverutils/mixin/Mixins.java
@@ -83,6 +83,10 @@ public enum Mixins implements IMixins {
             .setPhase(Phase.EARLY)
             .setApplyIf(() -> mixins.farmlandTramplingProtection)
             .addCommonMixins("minecraft.MixinBlockFarmland")),
+    BRIGADIER_COMMAND_PERMISSIONS(new MixinBuilder("Make command permissions work with Brigadier commands")
+            .setPhase(Phase.LATE)
+            .setApplyIf(() -> ranks.enabled && ranks.command_permissions)
+            .addCommonMixins("brigadier.MixinCommandNode", "brigadier.MixinLiteralCommandNode")),
     ;
     // spotless:on
 

--- a/src/main/java/serverutils/net/MessageRanks.java
+++ b/src/main/java/serverutils/net/MessageRanks.java
@@ -140,18 +140,18 @@ public class MessageRanks extends MessageToClient {
             for (ICommandWithPermission command : CommandUtils.getPermissionCommands()) {
                 String node = command.serverutilities$getPermissionNode();
                 DefaultPermissionLevel level = DefaultPermissionHandler.INSTANCE.getDefaultPermissionLevel(node);
-                IChatComponent name = new ChatComponentText(
-                        EnumChatFormatting.BLUE + "[" + command.serverutilities$getModName() + "]\n");
                 ConfigBoolean val = new ConfigBoolean(level == DefaultPermissionLevel.ALL);
+                IChatComponent desc = new ChatComponentText(
+                        EnumChatFormatting.BLUE + "[" + command.serverutilities$getModName() + "]\n");
+
                 if (command instanceof ICommand cmd) {
-                    commandPermissions.add(node, val, val, StringUtils.FLAG_ID_PERIOD_DEFAULTS)
-                            .setDisplayName(new ChatComponentTranslation(node))
-                            .setInfo(name.appendSibling(CommandUtils.getTranslatedUsage(cmd, p.getPlayer())));
+                    desc = desc.appendSibling(CommandUtils.getTranslatedUsage(cmd, p.getPlayer()));
                 } else if (command instanceof CommandNode<?>cmdNode) {
-                    commandPermissions.add(node, val, val, StringUtils.FLAG_ID_PERIOD_DEFAULTS)
-                            .setDisplayName(new ChatComponentTranslation(node))
-                            .setInfo(name.appendSibling(new ChatComponentText(cmdNode.getUsageText())));
+                    desc = desc.appendSibling(new ChatComponentText(cmdNode.getUsageText()));
                 }
+
+                commandPermissions.add(node, val, val, StringUtils.FLAG_ID_PERIOD_DEFAULTS)
+                        .setDisplayName(new ChatComponentTranslation(node)).setInfo(desc);
             }
         }
     }

--- a/src/main/java/serverutils/net/MessageRanks.java
+++ b/src/main/java/serverutils/net/MessageRanks.java
@@ -14,6 +14,8 @@ import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
 
+import com.mojang.brigadier.tree.CommandNode;
+
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import it.unimi.dsi.fastutil.ints.IntComparators;
@@ -141,9 +143,15 @@ public class MessageRanks extends MessageToClient {
                 IChatComponent name = new ChatComponentText(
                         EnumChatFormatting.BLUE + "[" + command.serverutilities$getModName() + "]\n");
                 ConfigBoolean val = new ConfigBoolean(level == DefaultPermissionLevel.ALL);
-                commandPermissions.add(node, val, val, StringUtils.FLAG_ID_PERIOD_DEFAULTS)
-                        .setDisplayName(new ChatComponentTranslation(node)).setInfo(
-                                name.appendSibling(CommandUtils.getTranslatedUsage((ICommand) command, p.getPlayer())));
+                if (command instanceof ICommand cmd) {
+                    commandPermissions.add(node, val, val, StringUtils.FLAG_ID_PERIOD_DEFAULTS)
+                            .setDisplayName(new ChatComponentTranslation(node))
+                            .setInfo(name.appendSibling(CommandUtils.getTranslatedUsage(cmd, p.getPlayer())));
+                } else if (command instanceof CommandNode<?>cmdNode) {
+                    commandPermissions.add(node, val, val, StringUtils.FLAG_ID_PERIOD_DEFAULTS)
+                            .setDisplayName(new ChatComponentTranslation(node))
+                            .setInfo(name.appendSibling(new ChatComponentText(cmdNode.getUsageText())));
+                }
             }
         }
     }

--- a/src/main/java/serverutils/ranks/ICommandWithPermission.java
+++ b/src/main/java/serverutils/ranks/ICommandWithPermission.java
@@ -7,8 +7,6 @@ import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommand;
 import net.minecraft.entity.player.EntityPlayerMP;
 
-import org.spongepowered.asm.mixin.Unique;
-
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.LoaderState;
 import serverutils.ServerUtilitiesPermissions;
@@ -41,7 +39,6 @@ public interface ICommandWithPermission {
         return false;
     }
 
-    @Unique
     default void serverUtilities$registerPermissions() {
         String node = this.serverutilities$getPermissionNode();
         DefaultPermissionLevel level = serverUtilities$getDefaultLevel();
@@ -62,13 +59,12 @@ public interface ICommandWithPermission {
         }
     }
 
-    @Unique
     default DefaultPermissionLevel serverUtilities$getDefaultLevel() {
         if (this instanceof CommandBase cmdBase) {
             return cmdBase.getRequiredPermissionLevel() > 0 ? DefaultPermissionLevel.OP : DefaultPermissionLevel.ALL;
         }
 
-        // Command permissions function as overrides, so it's fine to return OP for Brigadier commands
+        // Command permissions function as overrides, so it's fine to return OP for non-CommandBase commands
         // Only used for display purposes in the rank edit GUI
         return DefaultPermissionLevel.OP;
     }

--- a/src/main/java/serverutils/ranks/ICommandWithPermission.java
+++ b/src/main/java/serverutils/ranks/ICommandWithPermission.java
@@ -3,9 +3,20 @@ package serverutils.ranks;
 import java.util.HashMap;
 import java.util.Map;
 
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommand;
 import net.minecraft.entity.player.EntityPlayerMP;
 
 import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Unique;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.LoaderState;
+import serverutils.ServerUtilitiesPermissions;
+import serverutils.data.NodeEntry;
+import serverutils.lib.command.CommandTreeBase;
+import serverutils.lib.util.permission.DefaultPermissionLevel;
+import serverutils.lib.util.permission.PermissionAPI;
 
 public interface ICommandWithPermission {
 
@@ -21,5 +32,42 @@ public interface ICommandWithPermission {
 
     void serverutilities$setModName(@NotNull String modName);
 
-    boolean serverutilities$hasPermission(EntityPlayerMP player);
+    default String serverutilities$getModId() {
+        return "";
+    }
+
+    default void serverutilities$setModId(@NotNull String modId) {}
+
+    default boolean serverutilities$hasPermission(EntityPlayerMP player) {
+        return false;
+    }
+
+    @Unique
+    default void serverUtilities$registerPermissions() {
+        String node = this.serverutilities$getPermissionNode();
+        DefaultPermissionLevel level = serverUtilities$getDefaultLevel();
+
+        if (this instanceof CommandTreeBase tree) {
+            for (ICommand c : tree.getSubCommands()) {
+                ICommandWithPermission child = (ICommandWithPermission) c;
+                child.serverutilities$setPermissionNode(node.toLowerCase() + '.' + c.getCommandName());
+                child.serverutilities$setModName(this.serverutilities$getModName());
+                child.serverUtilities$registerPermissions();
+            }
+        }
+
+        if (Loader.instance().getLoaderState().ordinal() > LoaderState.PREINITIALIZATION.ordinal()) {
+            PermissionAPI.registerNode(node, level, "");
+        } else {
+            ServerUtilitiesPermissions.earlyPermissions.add(new NodeEntry(node, level, ""));
+        }
+    }
+
+    @Unique
+    default DefaultPermissionLevel serverUtilities$getDefaultLevel() {
+        if (this instanceof CommandBase cmdBase) {
+            return cmdBase.getRequiredPermissionLevel() > 0 ? DefaultPermissionLevel.OP : DefaultPermissionLevel.ALL;
+        }
+        return DefaultPermissionLevel.OP;
+    }
 }

--- a/src/main/java/serverutils/ranks/ICommandWithPermission.java
+++ b/src/main/java/serverutils/ranks/ICommandWithPermission.java
@@ -7,7 +7,6 @@ import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommand;
 import net.minecraft.entity.player.EntityPlayerMP;
 
-import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Unique;
 
 import cpw.mods.fml.common.Loader;
@@ -26,17 +25,17 @@ public interface ICommandWithPermission {
 
     String serverutilities$getPermissionNode();
 
-    void serverutilities$setPermissionNode(@NotNull String node);
+    void serverutilities$setPermissionNode(String node);
 
     String serverutilities$getModName();
 
-    void serverutilities$setModName(@NotNull String modName);
+    void serverutilities$setModName(String modName);
 
     default String serverutilities$getModId() {
         return "";
     }
 
-    default void serverutilities$setModId(@NotNull String modId) {}
+    default void serverutilities$setModId(String modId) {}
 
     default boolean serverutilities$hasPermission(EntityPlayerMP player) {
         return false;
@@ -68,6 +67,9 @@ public interface ICommandWithPermission {
         if (this instanceof CommandBase cmdBase) {
             return cmdBase.getRequiredPermissionLevel() > 0 ? DefaultPermissionLevel.OP : DefaultPermissionLevel.ALL;
         }
+
+        // Command permissions function as overrides, so it's fine to return OP for Brigadier commands
+        // Only used for display purposes in the rank edit GUI
         return DefaultPermissionLevel.OP;
     }
 }

--- a/src/mixins/java/serverutils/mixins/early/minecraft/MixinCommandHandler.java
+++ b/src/mixins/java/serverutils/mixins/early/minecraft/MixinCommandHandler.java
@@ -3,7 +3,6 @@ package serverutils.mixins.early.minecraft;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandHandler;
 import net.minecraft.command.ICommand;
 import net.minecraft.command.ICommandSender;
@@ -19,13 +18,8 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
 
 import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.common.LoaderState;
 import cpw.mods.fml.common.ModContainer;
-import serverutils.ServerUtilitiesPermissions;
-import serverutils.data.NodeEntry;
 import serverutils.lib.command.CommandTreeBase;
-import serverutils.lib.util.permission.DefaultPermissionLevel;
-import serverutils.lib.util.permission.PermissionAPI;
 import serverutils.ranks.ICommandWithPermission;
 import serverutils.ranks.Rank;
 
@@ -71,35 +65,6 @@ public abstract class MixinCommandHandler {
         ICommandWithPermission cmd = (ICommandWithPermission) command;
         cmd.serverutilities$setPermissionNode(PERMISSION_REPLACE_MATCHER.reset(node.toLowerCase()).replaceAll("_"));
         cmd.serverutilities$setModName(container == null ? "Minecraft" : container.getName());
-        serverUtilities$registerPermissions(cmd);
-    }
-
-    @Unique
-    private DefaultPermissionLevel serverUtilities$getDefaultLevel(ICommandWithPermission command) {
-        if (command instanceof CommandBase cmdBase) {
-            return cmdBase.getRequiredPermissionLevel() > 0 ? DefaultPermissionLevel.OP : DefaultPermissionLevel.ALL;
-        }
-        return DefaultPermissionLevel.OP;
-    }
-
-    @Unique
-    private void serverUtilities$registerPermissions(ICommandWithPermission command) {
-        String node = command.serverutilities$getPermissionNode();
-        DefaultPermissionLevel level = serverUtilities$getDefaultLevel(command);
-
-        if (command instanceof CommandTreeBase tree) {
-            for (ICommand c : tree.getSubCommands()) {
-                ICommandWithPermission child = (ICommandWithPermission) c;
-                child.serverutilities$setPermissionNode(node.toLowerCase() + '.' + c.getCommandName());
-                child.serverutilities$setModName(command.serverutilities$getModName());
-                serverUtilities$registerPermissions(child);
-            }
-        }
-
-        if (Loader.instance().getLoaderState().ordinal() > LoaderState.PREINITIALIZATION.ordinal()) {
-            PermissionAPI.registerNode(node, level, "");
-        } else {
-            ServerUtilitiesPermissions.earlyPermissions.add(new NodeEntry(node, level, ""));
-        }
+        cmd.serverUtilities$registerPermissions();
     }
 }

--- a/src/mixins/java/serverutils/mixins/late/brigadier/MixinCommandNode.java
+++ b/src/mixins/java/serverutils/mixins/late/brigadier/MixinCommandNode.java
@@ -1,0 +1,31 @@
+package serverutils.mixins.late.brigadier;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.brigadier.tree.CommandNode;
+
+import cpw.mods.fml.common.eventhandler.Event;
+import serverutils.ranks.ICommandWithPermission;
+import serverutils.ranks.Ranks;
+
+@Mixin(value = CommandNode.class, remap = false)
+public abstract class MixinCommandNode<S> {
+
+    @ModifyReturnValue(method = "canUse", at = @At(value = "RETURN"), remap = false)
+    private boolean serverutilities$brigadierExecute(boolean original, @Local(argsOnly = true) S source) {
+        if (!(source instanceof EntityPlayerMP player) || !(this instanceof ICommandWithPermission permission))
+            return original;
+        Event.Result result = Ranks.INSTANCE
+                .getPermissionResult(player, permission.serverutilities$getPermissionNode(), true);
+        if (result == Event.Result.DEFAULT) {
+            return original;
+        }
+
+        return result == Event.Result.ALLOW;
+    }
+}

--- a/src/mixins/java/serverutils/mixins/late/brigadier/MixinCommandNode.java
+++ b/src/mixins/java/serverutils/mixins/late/brigadier/MixinCommandNode.java
@@ -18,8 +18,10 @@ public abstract class MixinCommandNode<S> {
 
     @ModifyReturnValue(method = "canUse", at = @At(value = "RETURN"), remap = false)
     private boolean serverutilities$brigadierExecute(boolean original, @Local(argsOnly = true) S source) {
-        if (!(source instanceof EntityPlayerMP player) || !(this instanceof ICommandWithPermission permission))
+        if (!(source instanceof EntityPlayerMP player) || !(this instanceof ICommandWithPermission permission)) {
             return original;
+        }
+
         Event.Result result = Ranks.INSTANCE
                 .getPermissionResult(player, permission.serverutilities$getPermissionNode(), true);
         if (result == Event.Result.DEFAULT) {

--- a/src/mixins/java/serverutils/mixins/late/brigadier/MixinLiteralCommandNode.java
+++ b/src/mixins/java/serverutils/mixins/late/brigadier/MixinLiteralCommandNode.java
@@ -1,0 +1,69 @@
+package serverutils.mixins.late.brigadier;
+
+import java.util.function.Predicate;
+
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.RedirectModifier;
+import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.ModContainer;
+import serverutils.ranks.ICommandWithPermission;
+
+@Mixin(value = LiteralCommandNode.class, remap = false)
+public class MixinLiteralCommandNode<S> implements ICommandWithPermission {
+
+    @Unique
+    private String serverUtilities$permissionNode;
+
+    @Unique
+    private String serverUtilities$modName;
+
+    @Unique
+    private String serverUtilities$modId;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void serverutilities$ssfsasd(String literal, Command<S> command, Predicate<S> requirement,
+            CommandNode<S> redirect, RedirectModifier<S> modifier, boolean forks, CallbackInfo ci) {
+        ModContainer container = Loader.instance().activeModContainer();
+        serverutilities$setModName(container == null ? "" : container.getName());
+        serverutilities$setModId(container == null ? "" : container.getModId());
+    }
+
+    @Override
+    public String serverutilities$getPermissionNode() {
+        return serverUtilities$permissionNode;
+    }
+
+    @Override
+    public void serverutilities$setPermissionNode(@NotNull String node) {
+        this.serverUtilities$permissionNode = node;
+    }
+
+    @Override
+    public String serverutilities$getModName() {
+        return serverUtilities$modName;
+    }
+
+    @Override
+    public void serverutilities$setModName(@NotNull String modName) {
+        this.serverUtilities$modName = modName;
+    }
+
+    @Override
+    public String serverutilities$getModId() {
+        return serverUtilities$modId;
+    }
+
+    public void serverutilities$setModId(@NotNull String modId) {
+        this.serverUtilities$modId = modId;
+    }
+}

--- a/src/mixins/java/serverutils/mixins/late/brigadier/MixinLiteralCommandNode.java
+++ b/src/mixins/java/serverutils/mixins/late/brigadier/MixinLiteralCommandNode.java
@@ -31,7 +31,7 @@ public class MixinLiteralCommandNode<S> implements ICommandWithPermission {
     private String serverUtilities$modId;
 
     @Inject(method = "<init>", at = @At("RETURN"))
-    private void serverutilities$ssfsasd(String literal, Command<S> command, Predicate<S> requirement,
+    private void serverutilities$init(String literal, Command<S> command, Predicate<S> requirement,
             CommandNode<S> redirect, RedirectModifier<S> modifier, boolean forks, CallbackInfo ci) {
         ModContainer container = Loader.instance().activeModContainer();
         serverutilities$setModName(container == null ? "" : container.getName());


### PR DESCRIPTION
Currently the command permission system has no way of controlling Brigadier commands which is quite a big problem as more mods are beginning to use them.

This makes those commands work with the permission system just like regular minecraft commands.

Has been tested with each of the [gtnhlib team commands](https://github.com/GTNewHorizons/GTNHLib/blob/master/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamCommand.java) along with its various sub-commands and all seem to work as expected. 

Closes https://github.com/GTNewHorizons/ServerUtilities/issues/306