### PR TITLE
Prevent crash when viewing too many claims in JourneyMap

### DIFF
--- a/src/main/java/serverutils/integration/navigator/ClaimsLayerManager.java
+++ b/src/main/java/serverutils/integration/navigator/ClaimsLayerManager.java
@@ -1,6 +1,8 @@
 package serverutils.integration.navigator;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
@@ -13,8 +15,8 @@ import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
 import com.gtnewhorizons.navigator.api.model.locations.IWaypointAndLocationProvider;
 import com.gtnewhorizons.navigator.api.model.waypoints.Waypoint;
 
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
 import serverutils.client.gui.ClientClaimedChunks;
 import serverutils.net.MessageNavigatorRequest;
 import serverutils.net.MessageNavigatorValidateKnown;
@@ -22,6 +24,7 @@ import serverutils.net.MessageNavigatorValidateKnown;
 public class ClaimsLayerManager extends InteractableLayerManager {
 
     public static final ClaimsLayerManager INSTANCE = new ClaimsLayerManager();
+    private static final int MAX_CHUNKS_TO_VALIDATE = 2000;
     private long lastRequest, lastValidateRequest;
 
     public ClaimsLayerManager() {
@@ -73,9 +76,25 @@ public class ClaimsLayerManager extends InteractableLayerManager {
             Collection<IWaypointAndLocationProvider> visibleLocations = getVisibleLocations();
             if (visibleLocations.isEmpty()) return;
 
-            LongSet positions = new LongOpenHashSet();
+            LongList positions = new LongArrayList();
             visibleLocations.forEach(location -> positions.add(location.toLong()));
-            new MessageNavigatorValidateKnown(positions).sendToServer();
+            if (visibleLocations.size() <= MAX_CHUNKS_TO_VALIDATE) {
+                new MessageNavigatorValidateKnown(positions).sendToServer();
+            } else {
+                List<LongList> chunks = partitionList(positions);
+                for (LongList chunk : chunks) {
+                    new MessageNavigatorValidateKnown(chunk).sendToServer();
+                }
+            }
         }
+    }
+
+    private static List<LongList> partitionList(LongList list) {
+        List<LongList> chunkList = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += MAX_CHUNKS_TO_VALIDATE) {
+            int end = Math.min(i + MAX_CHUNKS_TO_VALIDATE, list.size());
+            chunkList.add(list.subList(i, end));
+        }
+        return chunkList;
     }
 }

--- a/src/main/java/serverutils/net/MessageNavigatorUpdateKnown.java
+++ b/src/main/java/serverutils/net/MessageNavigatorUpdateKnown.java
@@ -1,13 +1,11 @@
 package serverutils.net;
 
-import javax.annotation.Nonnull;
-
 import com.gtnewhorizon.gtnhlib.util.CoordinatePacker;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
 import serverutils.integration.navigator.NavigatorIntegration;
 import serverutils.lib.io.DataIn;
 import serverutils.lib.io.DataOut;
@@ -16,11 +14,11 @@ import serverutils.lib.net.NetworkWrapper;
 
 public class MessageNavigatorUpdateKnown extends MessageToClient {
 
-    private LongSet toRemove;
+    private LongList toRemove;
 
     public MessageNavigatorUpdateKnown() {}
 
-    public MessageNavigatorUpdateKnown(@Nonnull LongSet toRemove) {
+    public MessageNavigatorUpdateKnown(LongList toRemove) {
         this.toRemove = toRemove;
     }
 
@@ -38,7 +36,7 @@ public class MessageNavigatorUpdateKnown extends MessageToClient {
 
     @Override
     public void readData(DataIn data) {
-        toRemove = new LongOpenHashSet();
+        toRemove = new LongArrayList();
         while (data.isReadable()) {
             toRemove.add(data.readLong());
         }

--- a/src/main/java/serverutils/net/MessageNavigatorValidateKnown.java
+++ b/src/main/java/serverutils/net/MessageNavigatorValidateKnown.java
@@ -2,8 +2,8 @@ package serverutils.net;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
 import serverutils.ServerUtilitiesPermissions;
 import serverutils.data.ClaimedChunk;
 import serverutils.data.ClaimedChunks;
@@ -16,11 +16,11 @@ import serverutils.lib.util.permission.PermissionAPI;
 
 public class MessageNavigatorValidateKnown extends MessageToServer {
 
-    private LongSet knownPositions;
+    private LongList knownPositions;
 
     public MessageNavigatorValidateKnown() {}
 
-    public MessageNavigatorValidateKnown(LongSet knownPositions) {
+    public MessageNavigatorValidateKnown(LongList knownPositions) {
         this.knownPositions = knownPositions;
     }
 
@@ -38,7 +38,7 @@ public class MessageNavigatorValidateKnown extends MessageToServer {
 
     @Override
     public void readData(DataIn data) {
-        knownPositions = new LongOpenHashSet();
+        knownPositions = new LongArrayList();
         while (data.isReadable()) {
             knownPositions.add(data.readLong());
         }
@@ -49,7 +49,7 @@ public class MessageNavigatorValidateKnown extends MessageToServer {
         if (knownPositions.isEmpty()) return;
         if (ClaimedChunks.isActive()
                 && PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.CLAIMS_JOURNEYMAP)) {
-            LongSet toRemove = new LongOpenHashSet();
+            LongList toRemove = new LongArrayList();
             ChunkDimPos mut = new ChunkDimPos();
             for (long pos : knownPositions) {
                 ClaimedChunk chunk = ClaimedChunks.instance.getChunk(mut.set(pos, player.dimension));


### PR DESCRIPTION
Changes the map layer to validate a maximum of 2000 locations at once to prevent players being kicked because they send to big of a packet.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24193