### PR TITLE
Add transfer packet backport (1.20.5 for 1.7.10)

### DIFF
--- a/src/main/java/serverutils/ServerUtilitiesConfig.java
+++ b/src/main/java/serverutils/ServerUtilitiesConfig.java
@@ -42,6 +42,7 @@ public class ServerUtilitiesConfig {
     public static final Pregen pregen = new Pregen();
     public static final Mixins mixins = new Mixins();
     public static final MOTD motd = new MOTD();
+    public static final Transfer transfer = new Transfer();
 
     public static class General {
 
@@ -798,5 +799,16 @@ public class ServerUtilitiesConfig {
         @Config.DefaultString("§aUptime: §f{uptime} §7| §bTPS: §f{tps}")
         @Config.Reloadable("server_motd")
         public String line2;
+    }
+
+    public static class Transfer {
+
+        @Config.Comment("Enable the /transfer command and transfer packet.")
+        @Config.DefaultBoolean(true)
+        public boolean enabled;
+
+        @Config.Comment("Whitelist of allowed transfer hostnames. Empty = allow all.")
+        @Config.DefaultStringList({})
+        public String[] whitelist;
     }
 }

--- a/src/main/java/serverutils/client/TransferClientHandler.java
+++ b/src/main/java/serverutils/client/TransferClientHandler.java
@@ -1,0 +1,56 @@
+package serverutils.client;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiMainMenu;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.multiplayer.GuiConnecting;
+import net.minecraft.client.multiplayer.ServerData;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import serverutils.ServerUtilities;
+
+@SideOnly(Side.CLIENT)
+public class TransferClientHandler {
+
+    public static void execute(String host, int port) {
+        Minecraft mc = Minecraft.getMinecraft();
+        mc.func_152344_a(() -> {
+            if (mc.func_147104_D() == null) {
+                ServerUtilities.LOGGER.warn("Ignoring transfer request in singleplayer");
+                return;
+            }
+
+            String address = port == 25565 ? host : host + ":" + port;
+            ServerData serverData = new ServerData("Transfer", address);
+            mc.displayGuiScreen(new GuiTransferring(serverData));
+        });
+    }
+
+    @SideOnly(Side.CLIENT)
+    static class GuiTransferring extends GuiScreen {
+
+        private final ServerData serverData;
+
+        GuiTransferring(ServerData serverData) {
+            this.serverData = serverData;
+        }
+
+        @Override
+        public void updateScreen() {
+            this.mc.displayGuiScreen(new GuiConnecting(new GuiMainMenu(), this.mc, this.serverData));
+        }
+
+        @Override
+        public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+            this.drawDefaultBackground();
+            this.drawCenteredString(
+                    this.fontRendererObj,
+                    "Transferring...",
+                    this.width / 2,
+                    this.height / 2 - 50,
+                    0xFFFFFF);
+            super.drawScreen(mouseX, mouseY, partialTicks);
+        }
+    }
+}

--- a/src/main/java/serverutils/command/ServerUtilitiesCommands.java
+++ b/src/main/java/serverutils/command/ServerUtilitiesCommands.java
@@ -167,5 +167,9 @@ public class ServerUtilitiesCommands {
         if (ServerUtilitiesConfig.commands.pregen) {
             event.registerServerCommand(new CmdPregen());
         }
+
+        if (ServerUtilitiesConfig.transfer.enabled) {
+            event.registerServerCommand(new TransferCommand());
+        }
     }
 }

--- a/src/main/java/serverutils/command/TransferCommand.java
+++ b/src/main/java/serverutils/command/TransferCommand.java
@@ -1,0 +1,58 @@
+package serverutils.command;
+
+import java.util.List;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatComponentText;
+
+import serverutils.net.TransferHelper;
+
+public class TransferCommand extends CommandBase {
+
+    @Override
+    public String getCommandName() {
+        return "transfer";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "/transfer <player> <hostname> [port]";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 3;
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        if (args.length < 2) {
+            throw new WrongUsageException(getCommandUsage(sender));
+        }
+
+        EntityPlayerMP player = getPlayer(sender, args[0]);
+        String hostname = args[1];
+
+        int port = 25565;
+        if (args.length >= 3) {
+            port = parseIntBounded(sender, args[2], 1, 65535);
+        }
+
+        TransferHelper.transfer(player, hostname, port);
+        sender.addChatMessage(
+                new ChatComponentText(
+                        "Transferring " + player.getCommandSenderName() + " to " + hostname + ":" + port));
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length == 1) {
+            return getListOfStringsMatchingLastWord(args, MinecraftServer.getServer().getAllUsernames());
+        }
+        return null;
+    }
+}

--- a/src/main/java/serverutils/net/MessageTransfer.java
+++ b/src/main/java/serverutils/net/MessageTransfer.java
@@ -1,0 +1,77 @@
+package serverutils.net;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import serverutils.ServerUtilities;
+import serverutils.ServerUtilitiesConfig;
+import serverutils.client.TransferClientHandler;
+import serverutils.lib.io.DataIn;
+import serverutils.lib.io.DataOut;
+import serverutils.lib.net.MessageToClient;
+import serverutils.lib.net.NetworkWrapper;
+
+public class MessageTransfer extends MessageToClient {
+
+    private String host;
+    private int port;
+
+    public MessageTransfer() {}
+
+    public MessageTransfer(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    @Override
+    public NetworkWrapper getWrapper() {
+        return ServerUtilitiesNetHandler.GENERAL;
+    }
+
+    @Override
+    public void writeData(DataOut data) {
+        data.writeString(host);
+        data.writeInt(port);
+    }
+
+    @Override
+    public void readData(DataIn data) {
+        host = data.readString();
+        port = data.readInt();
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void onMessage() {
+        if (!ServerUtilitiesConfig.transfer.enabled) {
+            ServerUtilities.LOGGER.info("Ignoring transfer request to {}:{} (disabled in config)", host, port);
+            return;
+        }
+
+        if (host == null || host.isEmpty() || port < 1 || port > 65535) {
+            ServerUtilities.LOGGER.warn("Ignoring invalid transfer request: host={}, port={}", host, port);
+            return;
+        }
+
+        if (!isHostAllowed(host, port)) {
+            ServerUtilities.LOGGER.warn("Ignoring transfer request to {}:{} (not in whitelist)", host, port);
+            return;
+        }
+
+        ServerUtilities.LOGGER.info("Server requested transfer to {}:{}", host, port);
+        TransferClientHandler.execute(host, port);
+    }
+
+    private static boolean isHostAllowed(String host, int port) {
+        String[] whitelist = ServerUtilitiesConfig.transfer.whitelist;
+        if (whitelist == null || whitelist.length == 0) {
+            return true;
+        }
+        String hostPort = host + ":" + port;
+        for (String entry : whitelist) {
+            if (entry.equalsIgnoreCase(host) || entry.equalsIgnoreCase(hostPort)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/serverutils/net/ServerUtilitiesNetHandler.java
+++ b/src/main/java/serverutils/net/ServerUtilitiesNetHandler.java
@@ -25,6 +25,7 @@ public class ServerUtilitiesNetHandler {
         GENERAL.register(new MessageUpdateTabName());
         GENERAL.register(new MessageInvseeContainer());
         GENERAL.register(new MessageInvseeSwitch());
+        GENERAL.register(new MessageTransfer());
 
         CLAIMS.register(new MessageClaimedChunksRequest());
         CLAIMS.register(new MessageClaimedChunksUpdate());

--- a/src/main/java/serverutils/net/TransferHelper.java
+++ b/src/main/java/serverutils/net/TransferHelper.java
@@ -1,0 +1,10 @@
+package serverutils.net;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+
+public class TransferHelper {
+
+    public static void transfer(EntityPlayerMP player, String host, int port) {
+        new MessageTransfer(host, port).sendTo(player);
+    }
+}


### PR DESCRIPTION
backports 1.20.5 ClientboundTransferPacket to 1.7.10, allowing servers to seamlessly redirect players to another server:port without requiring BungeeCord/Velocity or other proxies. Migrated from Hodgepodge PR GTNewHorizons/Hodgepodge#833 per review feedback that a public API feature belongs in ServerUtilities.

- server sends host+port via ServerUtilities NetworkWrapper on the `serverutilities` channel
- client disconnects cleanly and reconnects to the target server
- /transfer <player> <hostname> [port] command (op level 3)
- TransferHelper.transfer() public API for programmatic use
- config: enableTransferPacket toggle, transferWhitelist for allowed hosts
- compatible with BungeeCord/Velocity/Bukkit proxies

wire format on the `serverutilities` channel:

| Field | Value |
|-|-|
| Channel | `serverutilities` |
| Direction | Server to Client |
| Discriminator | `0x0D` |

### Wire Format

Uses ServerUtilities DataOut/DataIn serialization:

| Field | Type | Description |
|-|-|-|
| host | String (DataOut.writeString) | Hostname or IP address (UTF-8, length-prefixed) |
| port | int (DataOut.writeInt) | Port number 1-65535 |

the client disconnect uses a deferred GuiTransferring screen to avoid a packet processing race in modded runTick -- updateController() can still dispatch stale packets after loadWorld(null) nulls the world, so the actual GuiConnecting is created in updateScreen() which runs after updateController in the tick cycle.

technically they could be done without this however it would be a hacky workaround for velocity, and would be a hit or miss. (higher chance of crash in dense populated gregtech machines area, and this just removes that chance)

An example can be seen here:

https://github.com/user-attachments/assets/36772a68-cdef-4f97-9ec2-b8fb63e4ae47

