### PR TITLE
fix transfer command block permission and host:port parsing

### DIFF
--- a/src/main/java/serverutils/command/TransferCommand.java
+++ b/src/main/java/serverutils/command/TransferCommand.java
@@ -25,7 +25,7 @@ public class TransferCommand extends CommandBase {
 
     @Override
     public int getRequiredPermissionLevel() {
-        return 3;
+        return 2;
     }
 
     @Override
@@ -40,6 +40,17 @@ public class TransferCommand extends CommandBase {
         int port = 25565;
         if (args.length >= 3) {
             port = parseIntBounded(sender, args[2], 1, 65535);
+        } else {
+            int colonIdx = hostname.lastIndexOf(':');
+            if (colonIdx > 0 && colonIdx < hostname.length() - 1) {
+                try {
+                    port = Integer.parseInt(hostname.substring(colonIdx + 1));
+                    if (port < 1 || port > 65535) {
+                        throw new WrongUsageException(getCommandUsage(sender));
+                    }
+                    hostname = hostname.substring(0, colonIdx);
+                } catch (NumberFormatException ignored) {}
+            }
         }
 
         TransferHelper.transfer(player, hostname, port);


### PR DESCRIPTION
fixes #300

- lower permission level from 3 to 2 so command blocks can run /transfer (command blocks have permission level 2)
- parse host:port format from the hostname argument, so /transfer @p mc.stonelegion.com:25585 works correctly instead of producing mc.stonelegion.com:25585:25565

Technically you needed to use `transfer @p mc.stonelegion.com 25585`