### PR TITLE
Fix /rtp & other tp commands

### DIFF
--- a/src/main/java/serverutils/command/tp/CmdRTP.java
+++ b/src/main/java/serverutils/command/tp/CmdRTP.java
@@ -44,11 +44,15 @@ public class CmdRTP extends CmdBase {
         }
         ServerUtilitiesPlayerData data = ServerUtilitiesPlayerData.get(CommandUtils.getForgePlayer(player));
         data.checkTeleportCooldown(sender, TeleportType.RTP);
-        TeleporterDimPos pos = findBlockPos(
-                player.mcServer.worldServerForDimension(ServerUtilitiesConfig.world.spawn_dimension),
-                player,
-                0);
+
+        World world = player.mcServer.worldServerForDimension(ServerUtilitiesConfig.world.spawn_dimension);
+        boolean prevFindingSpawnPoint = world.findingSpawnPoint;
+        world.findingSpawnPoint = true;
+
+        TeleporterDimPos pos = findBlockPos(world, player, 0);
         data.teleport(pos, TeleportType.RTP, null);
+
+        world.findingSpawnPoint = prevFindingSpawnPoint;
     }
 
     private TeleporterDimPos findBlockPos(World world, EntityPlayerMP player, int depth) {

--- a/src/main/java/serverutils/lib/math/TeleporterDimPos.java
+++ b/src/main/java/serverutils/lib/math/TeleporterDimPos.java
@@ -6,7 +6,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.play.server.S1FPacketSetExperience;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 
 import serverutils.ServerUtilities;
@@ -42,7 +41,7 @@ public class TeleporterDimPos {
         return new BlockDimPos(posX, posY, posZ, dim);
     }
 
-    public void placeEntity(World world, Entity entity, float yaw) {
+    public void placeEntity(Entity entity, float yaw) {
         entity.motionX = entity.motionY = entity.motionZ = 0D;
         entity.fallDistance = 0F;
 
@@ -51,6 +50,8 @@ public class TeleporterDimPos {
         } else {
             entity.setLocationAndAngles(posX, posY, posZ, yaw, entity.rotationPitch);
         }
+
+        entity.worldObj.updateEntityWithOptionalForce(entity, false);
     }
 
     @Nullable
@@ -61,15 +62,12 @@ public class TeleporterDimPos {
 
         if (ServerUtilitiesConfig.debugging.log_teleport) {
             ServerUtilities.LOGGER.info(
-                    "Teleporting '" + entity.getCommandSenderName()
-                            + "' to ["
-                            + posX
-                            + ','
-                            + posY
-                            + ','
-                            + posZ
-                            + "] in "
-                            + ServerUtils.getDimensionName(dim).getUnformattedText());
+                    "Teleporting '{}' to [{},{},{}] in {}",
+                    entity.getCommandSenderName(),
+                    posX,
+                    posY,
+                    posZ,
+                    ServerUtils.getDimensionName(dim).getUnformattedText());
         }
 
         if (dim != entity.dimension) {
@@ -96,7 +94,7 @@ public class TeleporterDimPos {
             }
         }
 
-        placeEntity(entity.worldObj, entity, entity.rotationYaw);
+        placeEntity(entity, entity.rotationYaw);
         return entity;
     }
 }

--- a/src/main/java/serverutils/task/TeleportTask.java
+++ b/src/main/java/serverutils/task/TeleportTask.java
@@ -57,6 +57,12 @@ public class TeleportTask extends Task {
         } else if (secondsLeft <= 1) {
             Entity mount = player.ridingEntity;
             player.mountEntity(null);
+
+            boolean prevFindingSpawnPoint = player.worldObj.findingSpawnPoint;
+            if (TeleportType.RTP.equals(teleportType)) {
+                player.worldObj.findingSpawnPoint = true;
+            }
+
             if (mount != null) {
                 teleporter.teleport(mount);
             }
@@ -71,6 +77,10 @@ public class TeleportTask extends Task {
 
             if (extraTask != null) {
                 extraTask.execute(universe);
+            }
+
+            if (TeleportType.RTP.equals(teleportType)) {
+                player.worldObj.findingSpawnPoint = prevFindingSpawnPoint;
             }
         } else {
             secondsLeft -= 1;


### PR DESCRIPTION
When Hodgepodge's `preventEntityChunkLoading` is enabled any tp command that takes the entity into unloaded chunks will cause them to be infinitely stuck in the void and rtp completely fails to find a position to tp the player.

Janky fix inspired by https://github.com/GTNewHorizons/Hodgepodge/pull/848.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25025