### PR TITLE
Fix cursor jumping when closing rank editor GUI

### DIFF
--- a/src/main/java/serverutils/lib/gui/GuiBase.java
+++ b/src/main/java/serverutils/lib/gui/GuiBase.java
@@ -18,7 +18,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 
 import org.lwjgl.input.Keyboard;
-import org.lwjgl.input.Mouse;
 
 import com.gtnewhorizon.gtnhlib.util.FilesUtil;
 
@@ -146,22 +145,16 @@ public abstract class GuiBase extends Panel implements IOpenableGui {
 
     @Override
     public final void closeGui(boolean openPrevScreen) {
-        int mx = Mouse.getX();
-        int my = Mouse.getY();
-
         Minecraft mc = Minecraft.getMinecraft();
 
-        if (mc.thePlayer != null) {
+        if (openPrevScreen) {
+            mc.displayGuiScreen(getPrevScreen());
+        } else if (mc.thePlayer != null) {
             mc.thePlayer.closeScreen();
 
             if (mc.currentScreen == null) {
                 mc.setIngameFocus();
             }
-        }
-
-        if (openPrevScreen) {
-            mc.displayGuiScreen(getPrevScreen());
-            Mouse.setCursorPosition(mx, my);
         }
 
         onClosed();


### PR DESCRIPTION
closeScreen() was always called before displayGuiScreen(prevScreen), which internally triggered setIngameFocus() and grabbed/centered the mouse. setCursorPosition then tried to restore the original position but was broken due to a LWJGL2 coordinate mismatch (getY() is bottom-origin, setCursorPosition expects top-origin), causing the cursor to land at a mirrored position (e.g. top-right click -> cursor ends up at bottom-right).

Fixed by skipping closeScreen() when a previous screen is being opened — the mouse is never grabbed so no restoration is needed.