### PR TITLE
Fix breeding not working in claims with mob spawns disabled

### DIFF
--- a/src/main/java/serverutils/handlers/ServerUtilitiesWorldEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesWorldEventHandler.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import cpw.mods.fml.common.eventhandler.Event;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.monster.IMob;
@@ -15,7 +16,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.World;
-import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.world.ExplosionEvent;
 import net.minecraftforge.event.world.WorldEvent;
 
@@ -38,10 +39,10 @@ import serverutils.pregenerator.ChunkLoaderManager;
 public class ServerUtilitiesWorldEventHandler {
 
     @SubscribeEvent
-    public static void onMobSpawned(EntityJoinWorldEvent event) {
+    public static void onMobSpawned(LivingSpawnEvent.CheckSpawn event) {
         if (!event.world.isRemote && !isEntityAllowed(event.entity)) {
             event.entity.setDead();
-            event.setCanceled(true);
+            event.setResult(Event.Result.DENY);
         }
     }
 

--- a/src/main/java/serverutils/handlers/ServerUtilitiesWorldEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesWorldEventHandler.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-import cpw.mods.fml.common.eventhandler.Event;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.monster.IMob;
@@ -22,6 +21,7 @@ import net.minecraftforge.event.world.WorldEvent;
 
 import com.gtnewhorizon.gtnhlib.eventbus.EventBusSubscriber;
 
+import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import serverutils.ServerUtilities;
 import serverutils.ServerUtilitiesConfig;


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
`EntityJoinWorldEvent` also affected animal breeding so this changes the event to `LivingSpawnEvent.CheckSpawn` which does not. Natural mob spawns and those from spawners are still affected.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25765

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
