### PR TITLE
Fix /back tp offsets

### DIFF
--- a/src/main/java/serverutils/command/tp/CmdBack.java
+++ b/src/main/java/serverutils/command/tp/CmdBack.java
@@ -60,6 +60,13 @@ public class CmdBack extends CmdBase {
             }
         };
 
-        data.teleport(TeleporterDimPos.of(lastPos.posX, lastPos.posY + 0.5D, lastPos.posZ, lastPos.dim), BACK, task);
+        TeleporterDimPos pos;
+        if(lastTeleportLog.teleportType.equals(TeleportType.RESPAWN)) {
+            pos = TeleporterDimPos.of(lastPos.posX + 0.5D, lastPos.posY + 0.3D, lastPos.posZ + 0.5D, lastPos.dim);
+        } else {
+            pos = lastPos.teleporter();
+        }
+
+        data.teleport(pos, BACK, task);
     }
 }

--- a/src/main/java/serverutils/command/tp/CmdBack.java
+++ b/src/main/java/serverutils/command/tp/CmdBack.java
@@ -61,7 +61,7 @@ public class CmdBack extends CmdBase {
         };
 
         TeleporterDimPos pos;
-        if(lastTeleportLog.teleportType.equals(TeleportType.RESPAWN)) {
+        if (lastTeleportLog.teleportType.equals(TeleportType.RESPAWN)) {
             pos = TeleporterDimPos.of(lastPos.posX + 0.5D, lastPos.posY + 0.3D, lastPos.posZ + 0.5D, lastPos.dim);
         } else {
             pos = lastPos.teleporter();


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Re-adds the +0.5 offset to x and z coords to ensure the player doesn't spawn in a wall and lowers the y offset from 0.5 to 0.3 which is enough to spawn above a grave while not hitting the block above.

Closes https://github.com/GTNewHorizons/ServerUtilities/issues/323

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
