### PR TITLE
Fix `serverutilities.bypass_player_limit` allowing banned players

### DIFF
--- a/src/mixins/java/serverutils/mixins/early/minecraft/MixinNetHandlerLoginServer.java
+++ b/src/mixins/java/serverutils/mixins/early/minecraft/MixinNetHandlerLoginServer.java
@@ -2,10 +2,12 @@ package serverutils.mixins.early.minecraft;
 
 import static serverutils.ServerUtilitiesPermissions.BYPASS_PLAYER_LIMIT;
 
+import net.minecraft.server.management.ServerConfigurationManager;
 import net.minecraft.server.network.NetHandlerLoginServer;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
@@ -15,6 +17,11 @@ import serverutils.lib.util.permission.PermissionAPI;
 
 @Mixin(NetHandlerLoginServer.class)
 public class MixinNetHandlerLoginServer {
+
+
+    /// Return value of {@link ServerConfigurationManager#allowUserToConnect(java.net.SocketAddress, GameProfile)} when the server is full.
+    @Unique
+    private static final String SERVER_FULL = "The server is full!";
 
     @Shadow
     private GameProfile field_147337_i;
@@ -29,7 +36,7 @@ public class MixinNetHandlerLoginServer {
             return original;
         }
 
-        if (PermissionAPI.hasPermission(field_147337_i, BYPASS_PLAYER_LIMIT, null)) {
+        if (SERVER_FULL.equals(original) && PermissionAPI.hasPermission(field_147337_i, BYPASS_PLAYER_LIMIT, null)) {
             return null;
         }
 

--- a/src/mixins/java/serverutils/mixins/early/minecraft/MixinNetHandlerLoginServer.java
+++ b/src/mixins/java/serverutils/mixins/early/minecraft/MixinNetHandlerLoginServer.java
@@ -18,8 +18,8 @@ import serverutils.lib.util.permission.PermissionAPI;
 @Mixin(NetHandlerLoginServer.class)
 public class MixinNetHandlerLoginServer {
 
-
-    /// Return value of {@link ServerConfigurationManager#allowUserToConnect(java.net.SocketAddress, GameProfile)} when the server is full.
+    /// Return value of {@link ServerConfigurationManager#allowUserToConnect(java.net.SocketAddress, GameProfile)} when
+    /// the server is full.
     @Unique
     private static final String SERVER_FULL = "The server is full!";
 


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/ServerUtilities/issues/329
## Summary
<!-- Briefly describe what this PR changes and why. -->
The disconnect reason was never checked before allowing a player with the `serverutilities.bypass_player_limit` permission to join. This allowed both banned and non-whitelisted (on whitelisted servers) players to join.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
