### PR TITLE
JourneyMap 6 support for claims overlay and various improvements

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.8.105-GTNH:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:EnderIO:2.10.31:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:Random-Things:2.7.7:dev") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:Navigator:1.1.3:dev")
+    compileOnly("com.github.GTNewHorizons:Navigator:1.1.7:dev")
     compileOnly('info.journeymap:journeymap-api-forge:1.7.10-2.0.0')
     compileOnly('org.jetbrains:annotations:26.1.0')
     compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev') {transitive = false}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.8.105-GTNH:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:EnderIO:2.10.31:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:Random-Things:2.7.7:dev") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:Navigator:1.1.7:dev")
+    compileOnly("com.github.GTNewHorizons:Navigator:1.1.8:dev")
     compileOnly('info.journeymap:journeymap-api-forge:1.7.10-2.0.0')
     compileOnly('org.jetbrains:annotations:26.1.0')
     compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev') {transitive = false}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,6 +7,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:EnderIO:2.10.31:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:Random-Things:2.7.7:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:Navigator:1.1.3:dev")
+    compileOnly('info.journeymap:journeymap-api-forge:1.7.10-2.0.0')
     compileOnly('org.jetbrains:annotations:26.1.0')
     compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:Battlegear2:1.4.3:dev') {transitive = false}

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,4 +1,8 @@
 // Add any additional repositories for your dependencies here
 
 repositories {
+    maven {
+        name = "JourneyMap"
+        url = "https://maven.blamejared.com"
+    }
 }

--- a/src/main/java/serverutils/ServerUtilitiesCommon.java
+++ b/src/main/java/serverutils/ServerUtilitiesCommon.java
@@ -36,6 +36,7 @@ import serverutils.aurora.AuroraConfig;
 import serverutils.command.ServerUtilitiesCommands;
 import serverutils.data.ServerUtilitiesLoadedChunkManager;
 import serverutils.events.ServerReloadEvent;
+import serverutils.handlers.ServerUtilitiesServerEventHandler;
 import serverutils.lib.OtherMods;
 import serverutils.lib.config.ConfigGroup;
 import serverutils.lib.config.IConfigCallback;
@@ -114,6 +115,7 @@ public class ServerUtilitiesCommon {
     }
 
     public void onServerAboutToStart(FMLServerAboutToStartEvent event) {
+        ServerUtilitiesServerEventHandler.clearServerTasks();
         Universe.onServerAboutToStart(event);
         MinecraftForge.EVENT_BUS.register(Universe.get());
         FMLCommonHandler.instance().bus().register(Universe.get());
@@ -163,6 +165,7 @@ public class ServerUtilitiesCommon {
         Aurora.stop();
         MinecraftForge.EVENT_BUS.unregister(oldUniverse);
         FMLCommonHandler.instance().bus().unregister(oldUniverse);
+        ServerUtilitiesServerEventHandler.clearServerTasks();
     }
 
     public void registerTasks() {

--- a/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesClientEventHandler.java
@@ -63,7 +63,7 @@ public class ServerUtilitiesClientEventHandler {
         shutdownTime = 0L;
         SidedUtils.SERVER_MODS.clear();
         if (OtherMods.isNavigatorLoaded()) {
-            NavigatorIntegration.CLAIMS.clear();
+            NavigatorIntegration.clearSession();
         }
         TabSkinCache.INSTANCE.clear();
         TabChannelHandler.INSTANCE.clear();

--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -58,6 +58,10 @@ public class ServerUtilitiesServerEventHandler {
         SERVER_TASKS.add(task);
     }
 
+    public static void clearServerTasks() {
+        SERVER_TASKS.clear();
+    }
+
     private static final Pattern STRIKETHROUGH_PATTERN = Pattern.compile("~~(.+?)~~");
     private static final String STRIKETHROUGH_REPLACE = "&m$1&m";
     private static final Pattern BOLD_PATTERN = Pattern.compile("\\*\\*(.+?)\\*\\*|__(.+?)__");
@@ -197,7 +201,11 @@ public class ServerUtilitiesServerEventHandler {
         if (event.phase == TickEvent.Phase.START) {
             Runnable task;
             while ((task = SERVER_TASKS.poll()) != null) {
-                task.run();
+                try {
+                    task.run();
+                } catch (RuntimeException e) {
+                    ServerUtilities.LOGGER.error("Error running scheduled server task", e);
+                }
             }
         }
 

--- a/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
+++ b/src/main/java/serverutils/handlers/ServerUtilitiesServerEventHandler.java
@@ -5,6 +5,8 @@ import static serverutils.ServerUtilitiesNotifications.PLAYER_AFK;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.regex.Pattern;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -49,6 +51,12 @@ import serverutils.ranks.Ranks;
 
 @EventBusSubscriber
 public class ServerUtilitiesServerEventHandler {
+
+    private static final Queue<Runnable> SERVER_TASKS = new ConcurrentLinkedQueue<>();
+
+    public static void scheduleServerTask(Runnable task) {
+        SERVER_TASKS.add(task);
+    }
 
     private static final Pattern STRIKETHROUGH_PATTERN = Pattern.compile("~~(.+?)~~");
     private static final String STRIKETHROUGH_REPLACE = "&m$1&m";
@@ -186,6 +194,13 @@ public class ServerUtilitiesServerEventHandler {
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.ServerTickEvent event) {
+        if (event.phase == TickEvent.Phase.START) {
+            Runnable task;
+            while ((task = SERVER_TASKS.poll()) != null) {
+                task.run();
+            }
+        }
+
         if (!Universe.loaded()) {
             return;
         }

--- a/src/main/java/serverutils/integration/navigator/ClaimsLayerManager.java
+++ b/src/main/java/serverutils/integration/navigator/ClaimsLayerManager.java
@@ -16,7 +16,9 @@ import com.gtnewhorizons.navigator.api.util.Util;
 
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongList;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import serverutils.client.gui.ClientClaimedChunks;
+import serverutils.lib.math.ChunkDimPos;
 import serverutils.net.MessageNavigatorRequest;
 import serverutils.net.MessageNavigatorValidateKnown;
 
@@ -58,6 +60,27 @@ public class ClaimsLayerManager extends InteractableLayerManager {
                 .get(NavigatorIntegration.mutablePos.set(chunkX, chunkZ, dim));
         if (data == null) return null;
         return new ClaimsLocation(chunkX, chunkZ, dim, data);
+    }
+
+    @Override
+    protected Collection<? extends ILocationProvider> generateVisibleLocations(int minBlockX, int minBlockZ,
+            int maxBlockX, int maxBlockZ, int dimension) {
+        int minChunkX = Util.coordBlockToChunk(minBlockX);
+        int minChunkZ = Util.coordBlockToChunk(minBlockZ);
+        int maxChunkX = Util.coordBlockToChunk(maxBlockX);
+        int maxChunkZ = Util.coordBlockToChunk(maxBlockZ);
+        List<ClaimsLocation> locations = new ArrayList<>();
+        for (Object2ObjectMap.Entry<ChunkDimPos, ClientClaimedChunks.ChunkData> entry : NavigatorIntegration.CLAIMS
+                .object2ObjectEntrySet()) {
+            ChunkDimPos pos = entry.getKey();
+            if (pos.dim == dimension && pos.posX >= minChunkX
+                    && pos.posX <= maxChunkX
+                    && pos.posZ >= minChunkZ
+                    && pos.posZ <= maxChunkZ) {
+                locations.add(new ClaimsLocation(pos.posX, pos.posZ, pos.dim, entry.getValue()));
+            }
+        }
+        return locations;
     }
 
     @Override

--- a/src/main/java/serverutils/integration/navigator/ClaimsLayerManager.java
+++ b/src/main/java/serverutils/integration/navigator/ClaimsLayerManager.java
@@ -12,8 +12,7 @@ import com.gtnewhorizons.navigator.api.model.layers.InteractableLayerManager;
 import com.gtnewhorizons.navigator.api.model.layers.LayerRenderer;
 import com.gtnewhorizons.navigator.api.model.layers.UniversalInteractableRenderer;
 import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
-import com.gtnewhorizons.navigator.api.model.locations.IWaypointAndLocationProvider;
-import com.gtnewhorizons.navigator.api.model.waypoints.Waypoint;
+import com.gtnewhorizons.navigator.api.util.Util;
 
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongList;
@@ -34,12 +33,14 @@ public class ClaimsLayerManager extends InteractableLayerManager {
     @Nullable
     @Override
     protected LayerRenderer addLayerRenderer(InteractableLayerManager manager, SupportedMods mod) {
-        return new UniversalInteractableRenderer(manager).withClickAction(NavigatorIntegration::claimChunk)
-                .withRenderStep(location -> new ClaimsRenderStep((ClaimsLocation) location));
+        UniversalInteractableRenderer renderer = new UniversalInteractableRenderer(manager)
+                .withClickAction(NavigatorIntegration::handleMapClick);
+        renderer.withRenderStep(location -> new ClaimsRenderStep((ClaimsLocation) location));
+        if (Util.isJourneyMapV6Installed()) {
+            renderer.withJourneyMapV6Overlays(ClaimsPolygonOverlay::create, true);
+        }
+        return renderer;
     }
-
-    @Override
-    public void setActiveWaypoint(Waypoint waypoint) {}
 
     @Override
     public void onLayerToggled(boolean toEnabled) {
@@ -73,7 +74,7 @@ public class ClaimsLayerManager extends InteractableLayerManager {
         long now = System.currentTimeMillis();
         if (now - lastValidateRequest >= TimeUnit.SECONDS.toMillis(10)) {
             lastValidateRequest = now;
-            Collection<IWaypointAndLocationProvider> visibleLocations = getVisibleLocations();
+            Collection<ILocationProvider> visibleLocations = getVisibleLocations();
             if (visibleLocations.isEmpty()) return;
 
             LongList positions = new LongArrayList();

--- a/src/main/java/serverutils/integration/navigator/ClaimsLayerManager.java
+++ b/src/main/java/serverutils/integration/navigator/ClaimsLayerManager.java
@@ -37,7 +37,7 @@ public class ClaimsLayerManager extends InteractableLayerManager {
                 .withClickAction(NavigatorIntegration::handleMapClick);
         renderer.withRenderStep(location -> new ClaimsRenderStep((ClaimsLocation) location));
         if (Util.isJourneyMapV6Installed()) {
-            renderer.withJourneyMapV6Overlays(ClaimsPolygonOverlay::create, true);
+            renderer.withJourneyMapV6Overlays(ClaimsPolygonOverlay::create);
         }
         return renderer;
     }

--- a/src/main/java/serverutils/integration/navigator/ClaimsLocation.java
+++ b/src/main/java/serverutils/integration/navigator/ClaimsLocation.java
@@ -104,6 +104,7 @@ public class ClaimsLocation implements ILocationProvider {
         new MessageClaimedChunksModify(chunkX, chunkZ, selectionMode, chunks).sendToServer();
         new MessageNavigatorRequest(chunkX, chunkX, chunkZ, chunkZ).sendToServer();
         chunkData.setLoaded(!isLoaded());
+        ClaimsLayerManager.INSTANCE.forceRefresh();
     }
 
 }

--- a/src/main/java/serverutils/integration/navigator/ClaimsLocation.java
+++ b/src/main/java/serverutils/integration/navigator/ClaimsLocation.java
@@ -10,8 +10,7 @@ import net.minecraft.world.ChunkCoordIntPair;
 import org.lwjgl.input.Keyboard;
 
 import com.gtnewhorizons.navigator.api.NavigatorApi;
-import com.gtnewhorizons.navigator.api.model.locations.IWaypointAndLocationProvider;
-import com.gtnewhorizons.navigator.api.model.waypoints.Waypoint;
+import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
 import com.gtnewhorizons.navigator.api.util.Util;
 
 import serverutils.client.gui.ClientClaimedChunks;
@@ -19,7 +18,7 @@ import serverutils.lib.EnumTeamColor;
 import serverutils.net.MessageClaimedChunksModify;
 import serverutils.net.MessageNavigatorRequest;
 
-public class ClaimsLocation implements IWaypointAndLocationProvider {
+public class ClaimsLocation implements ILocationProvider {
 
     private final int blockX;
     private final int blockZ;
@@ -107,20 +106,4 @@ public class ClaimsLocation implements IWaypointAndLocationProvider {
         chunkData.setLoaded(!isLoaded());
     }
 
-    @Override
-    public Waypoint toWaypoint() {
-        toggleLoaded();
-        return null;
-    }
-
-    @Override
-    public boolean isActiveAsWaypoint() {
-        return false;
-    }
-
-    @Override
-    public void onWaypointCleared() {}
-
-    @Override
-    public void onWaypointUpdated(Waypoint waypoint) {}
 }

--- a/src/main/java/serverutils/integration/navigator/ClaimsLocation.java
+++ b/src/main/java/serverutils/integration/navigator/ClaimsLocation.java
@@ -68,6 +68,12 @@ public class ClaimsLocation implements ILocationProvider {
         return chunkData.isLoaded();
     }
 
+    boolean hasLoadedNeighbor(int offsetX, int offsetZ) {
+        ClientClaimedChunks.ChunkData neighbor = NavigatorIntegration.CLAIMS.get(
+                NavigatorIntegration.mutablePos.set(getChunkX() + offsetX, getChunkZ() + offsetZ, getDimensionId()));
+        return neighbor != null && neighbor.isLoaded();
+    }
+
     public String loadedHint() {
         return isLoaded() ? EnumChatFormatting.GREEN + I18n.format("serverutilities.lang.chunks.chunk_loaded") : "";
     }

--- a/src/main/java/serverutils/integration/navigator/ClaimsPolygonOverlay.java
+++ b/src/main/java/serverutils/integration/navigator/ClaimsPolygonOverlay.java
@@ -1,14 +1,17 @@
 package serverutils.integration.navigator;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 
 import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
 
 import journeymap.api.v2.client.display.PolygonOverlay;
+import journeymap.api.v2.client.model.MapPolygon;
 import journeymap.api.v2.client.model.ShapeProperties;
 import journeymap.api.v2.client.util.PolygonHelper;
 import journeymap.api.v2.common.Context;
+import journeymap.api.v2.common.util.BlockPos;
 import serverutils.ServerUtilities;
 import serverutils.lib.icon.Color4I;
 
@@ -21,15 +24,60 @@ final class ClaimsPolygonOverlay {
         Color4I color = location.getTeamColor().getColor();
         if (!location.isLoaded()) color = color.addBrightness(-0.3F);
 
-        ShapeProperties shape = new ShapeProperties().setFillColor(color.rgb()).setFillOpacity(135F / 255F)
+        ShapeProperties fill = new ShapeProperties().setFillColor(color.rgb()).setFillOpacity(135F / 255F)
                 .setStrokeOpacity(0F);
-        PolygonOverlay overlay = new PolygonOverlay(
-                ServerUtilities.MOD_ID,
-                location.getDimensionId(),
-                shape,
-                PolygonHelper.createChunkPolygon(location.getChunkX(), 64, location.getChunkZ()));
-        overlay.setOverlayGroupName(ClaimsLocation.class.getName())
-                .setActiveUIs(Context.UI.Fullscreen, Context.UI.Minimap).setDisplayOrder(100);
-        return Collections.singleton(overlay);
+        List<PolygonOverlay> overlays = new ArrayList<>();
+        overlays.add(
+                createOverlay(
+                        location,
+                        fill,
+                        PolygonHelper.createChunkPolygon(location.getChunkX(), 64, location.getChunkZ()),
+                        100,
+                        Context.UI.Fullscreen,
+                        Context.UI.Minimap));
+        if (!location.isLoaded()) return overlays;
+
+        int x = location.getChunkX() << 4;
+        int z = location.getChunkZ() << 4;
+        boolean north = location.hasLoadedNeighbor(0, -1);
+        boolean south = location.hasLoadedNeighbor(0, 1);
+        boolean west = location.hasLoadedNeighbor(-1, 0);
+        boolean east = location.hasLoadedNeighbor(1, 0);
+        int horizontalMinX = x - (west ? 1 : 0);
+        int horizontalMaxX = x + 16 + (east ? 1 : 0);
+        int verticalMinZ = z - (north ? 1 : 0);
+        int verticalMaxZ = z + 16 + (south ? 1 : 0);
+        if (!north) {
+            overlays.add(createEdge(location, horizontalMinX, z, horizontalMaxX, z + 1));
+        }
+        if (!south) {
+            overlays.add(createEdge(location, horizontalMinX, z + 15, horizontalMaxX, z + 16));
+        }
+        if (!west) {
+            overlays.add(createEdge(location, x, verticalMinZ, x + 1, verticalMaxZ));
+        }
+        if (!east) {
+            overlays.add(createEdge(location, x + 15, verticalMinZ, x + 16, verticalMaxZ));
+        }
+        return overlays;
+    }
+
+    private static PolygonOverlay createEdge(ClaimsLocation location, int minX, int minZ, int maxX, int maxZ) {
+        ShapeProperties edge = new ShapeProperties().setFillColor(ClaimsRenderStep.LOADED_BORDER.rgb())
+                .setFillOpacity(230F / 255F).setStrokeOpacity(0F);
+        return createOverlay(
+                location,
+                edge,
+                PolygonHelper.createBlockRect(new BlockPos(minX, 64, minZ), new BlockPos(maxX, 64, maxZ)),
+                101,
+                Context.UI.Minimap);
+    }
+
+    private static PolygonOverlay createOverlay(ClaimsLocation location, ShapeProperties shape, MapPolygon polygon,
+            int displayOrder, Context.UI... activeUIs) {
+        PolygonOverlay overlay = new PolygonOverlay(ServerUtilities.MOD_ID, location.getDimensionId(), shape, polygon);
+        overlay.setOverlayGroupName(ClaimsLocation.class.getName()).setActiveUIs(activeUIs)
+                .setDisplayOrder(displayOrder);
+        return overlay;
     }
 }

--- a/src/main/java/serverutils/integration/navigator/ClaimsPolygonOverlay.java
+++ b/src/main/java/serverutils/integration/navigator/ClaimsPolygonOverlay.java
@@ -1,0 +1,35 @@
+package serverutils.integration.navigator;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import com.gtnewhorizons.navigator.api.model.locations.ILocationProvider;
+
+import journeymap.api.v2.client.display.PolygonOverlay;
+import journeymap.api.v2.client.model.ShapeProperties;
+import journeymap.api.v2.client.util.PolygonHelper;
+import journeymap.api.v2.common.Context;
+import serverutils.ServerUtilities;
+import serverutils.lib.icon.Color4I;
+
+final class ClaimsPolygonOverlay {
+
+    private ClaimsPolygonOverlay() {}
+
+    static Collection<?> create(ILocationProvider provider) {
+        ClaimsLocation location = (ClaimsLocation) provider;
+        Color4I color = location.getTeamColor().getColor();
+        if (!location.isLoaded()) color = color.addBrightness(-0.3F);
+
+        ShapeProperties shape = new ShapeProperties().setFillColor(color.rgb()).setFillOpacity(135F / 255F)
+                .setStrokeOpacity(0F);
+        PolygonOverlay overlay = new PolygonOverlay(
+                ServerUtilities.MOD_ID,
+                location.getDimensionId(),
+                shape,
+                PolygonHelper.createChunkPolygon(location.getChunkX(), 64, location.getChunkZ()));
+        overlay.setOverlayGroupName(ClaimsLocation.class.getName())
+                .setActiveUIs(Context.UI.Fullscreen, Context.UI.Minimap).setDisplayOrder(100);
+        return Collections.singleton(overlay);
+    }
+}

--- a/src/main/java/serverutils/integration/navigator/ClaimsRenderStep.java
+++ b/src/main/java/serverutils/integration/navigator/ClaimsRenderStep.java
@@ -2,11 +2,11 @@ package serverutils.integration.navigator;
 
 import java.util.List;
 
-import com.gtnewhorizons.navigator.api.model.steps.UniversalInteractableStep;
+import com.gtnewhorizons.navigator.api.model.steps.UniversalLocationInteractableStep;
 
 import serverutils.lib.icon.Color4I;
 
-public class ClaimsRenderStep extends UniversalInteractableStep<ClaimsLocation> {
+public class ClaimsRenderStep extends UniversalLocationInteractableStep<ClaimsLocation> {
 
     public ClaimsRenderStep(ClaimsLocation location) {
         super(location);

--- a/src/main/java/serverutils/integration/navigator/ClaimsRenderStep.java
+++ b/src/main/java/serverutils/integration/navigator/ClaimsRenderStep.java
@@ -3,22 +3,50 @@ package serverutils.integration.navigator;
 import java.util.List;
 
 import com.gtnewhorizons.navigator.api.model.steps.UniversalLocationInteractableStep;
+import com.gtnewhorizons.navigator.api.util.Util;
 
 import serverutils.lib.icon.Color4I;
 
 public class ClaimsRenderStep extends UniversalLocationInteractableStep<ClaimsLocation> {
+
+    static final Color4I LOADED_BORDER = Color4I.rgb(255, 80, 80).withAlpha(230);
 
     public ClaimsRenderStep(ClaimsLocation location) {
         super(location);
     }
 
     @Override
+    public void preRender(double x, double y, float drawScale, double zoom) {
+        setOffset(isJourneyMap ? -blockSize / 2D : 0D);
+    }
+
+    @Override
     public void draw(double x, double y, float drawScale, double zoom) {
-        Color4I teamColor = location.getTeamColor().getColor().withAlpha(135);
-        if (!location.isLoaded()) {
-            teamColor.addBrightness(-0.3f).drawD(x, y, getAdjustedWidth(), getAdjustedHeight());
-        } else {
-            teamColor.drawD(x, y, getAdjustedWidth(), getAdjustedHeight());
+        double width = getAdjustedWidth();
+        double height = getAdjustedHeight();
+        if (!isJourneyMap || !Util.isJourneyMapV6Installed()) {
+            Color4I teamColor = location.getTeamColor().getColor().withAlpha(135);
+            if (!location.isLoaded()) teamColor = teamColor.addBrightness(-0.3F);
+            teamColor.drawD(x, y, width, height);
+        }
+        if (!location.isLoaded()) return;
+
+        double border = Math.min(2D, Math.min(width, height) / 2D);
+        boolean north = location.hasLoadedNeighbor(0, -1);
+        boolean south = location.hasLoadedNeighbor(0, 1);
+        boolean west = location.hasLoadedNeighbor(-1, 0);
+        boolean east = location.hasLoadedNeighbor(1, 0);
+        double horizontalX = x - (west ? border : 0D);
+        double horizontalWidth = width + (west ? border : 0D) + (east ? border : 0D);
+        double verticalY = y - (north ? border : 0D);
+        double verticalHeight = height + (north ? border : 0D) + (south ? border : 0D);
+        if (!north) LOADED_BORDER.drawD(horizontalX, y, horizontalWidth, border);
+        if (!south) {
+            LOADED_BORDER.drawD(horizontalX, y + height - border, horizontalWidth, border);
+        }
+        if (!west) LOADED_BORDER.drawD(x, verticalY, border, verticalHeight);
+        if (!east) {
+            LOADED_BORDER.drawD(x + width - border, verticalY, border, verticalHeight);
         }
     }
 

--- a/src/main/java/serverutils/integration/navigator/NavigatorIntegration.java
+++ b/src/main/java/serverutils/integration/navigator/NavigatorIntegration.java
@@ -40,6 +40,7 @@ public class NavigatorIntegration {
                 ClientClaimedChunks.ChunkData oldData = CLAIMS.get(location);
                 if (oldData == null) {
                     CLAIMS.put(location, newData);
+                    refresh = true;
                     continue;
                 }
 

--- a/src/main/java/serverutils/integration/navigator/NavigatorIntegration.java
+++ b/src/main/java/serverutils/integration/navigator/NavigatorIntegration.java
@@ -76,7 +76,7 @@ public class NavigatorIntegration {
 
     public static void removeChunk(int chunkX, int chunkZ) {
         int dim = Minecraft.getMinecraft().thePlayer.dimension;
-        ClaimsLayerManager.INSTANCE.removeLocation(chunkX, chunkZ);
+        ClaimsLayerManager.INSTANCE.invalidateLocation(chunkX, chunkZ);
         CLAIMS.remove(mutablePos.set(chunkX, chunkZ, dim));
     }
 

--- a/src/main/java/serverutils/integration/navigator/NavigatorIntegration.java
+++ b/src/main/java/serverutils/integration/navigator/NavigatorIntegration.java
@@ -49,11 +49,19 @@ public class NavigatorIntegration {
                 oldData.setTeam(newData.team);
             }
 
-            if (OWNTEAM == null && team.isMember) {
-                OWNTEAM = team.chunkPos.values().iterator().next().copy().setLoaded(false);
+            if (team.isMember) {
+                OWNTEAM = new ClientClaimedChunks.ChunkData(team, 0);
             }
         }
         if (refresh) ClaimsLayerManager.INSTANCE.forceRefresh();
+    }
+
+    public static void clearSession() {
+        CLAIMS.clear();
+        OWNTEAM = null;
+        maxClaimedChunks = 0;
+        currentClaimedChunks = 0;
+        ClaimsLayerManager.INSTANCE.clearFullCache();
     }
 
     private static boolean needsRefresh(ClientClaimedChunks.ChunkData oldData, ClientClaimedChunks.ChunkData newData) {

--- a/src/main/java/serverutils/integration/navigator/NavigatorIntegration.java
+++ b/src/main/java/serverutils/integration/navigator/NavigatorIntegration.java
@@ -83,8 +83,16 @@ public class NavigatorIntegration {
         currentClaimedChunks = message.claimedChunks;
     }
 
-    public static boolean claimChunk(ClickPos pos) {
-        if (pos.getRenderStep() != null || !pos.isDoubleClick()) return false;
+    public static boolean handleMapClick(ClickPos pos) {
+        if (!pos.isDoubleClick()) return false;
+        if (pos.getLocationRenderStep() != null) {
+            if (pos.getLocationRenderStep().getLocation() instanceof ClaimsLocation location) {
+                location.toggleLoaded();
+                return true;
+            }
+            return false;
+        }
+
         int selectionMode = MessageClaimedChunksModify.CLAIM;
         int chunkX = pos.getChunkX();
         int chunkZ = pos.getChunkZ();

--- a/src/main/java/serverutils/integration/navigator/NavigatorIntegration.java
+++ b/src/main/java/serverutils/integration/navigator/NavigatorIntegration.java
@@ -2,6 +2,7 @@ package serverutils.integration.navigator;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.ChunkCoordIntPair;
@@ -30,6 +31,7 @@ public class NavigatorIntegration {
     }
 
     public static void updateMap(MessageNavigatorUpdate message) {
+        boolean refresh = false;
         for (ClientClaimedChunks.Team team : message.teams.values()) {
             for (Object2ObjectMap.Entry<ChunkDimPos, ClientClaimedChunks.ChunkData> pos : team.chunkPos
                     .object2ObjectEntrySet()) {
@@ -41,16 +43,27 @@ public class NavigatorIntegration {
                     continue;
                 }
 
+                refresh |= needsRefresh(oldData, newData);
                 oldData.setLoaded(newData.isLoaded());
                 oldData.setTeam(newData.team);
             }
-
-            ClaimsLayerManager.INSTANCE.forceRefresh();
 
             if (OWNTEAM == null && team.isMember) {
                 OWNTEAM = team.chunkPos.values().iterator().next().copy().setLoaded(false);
             }
         }
+        if (refresh) ClaimsLayerManager.INSTANCE.forceRefresh();
+    }
+
+    private static boolean needsRefresh(ClientClaimedChunks.ChunkData oldData, ClientClaimedChunks.ChunkData newData) {
+        ClientClaimedChunks.Team oldTeam = oldData.team;
+        ClientClaimedChunks.Team newTeam = newData.team;
+        return oldData.isLoaded() != newData.isLoaded() || oldTeam.uid != newTeam.uid
+                || oldTeam.color != newTeam.color
+                || oldTeam.isAlly != newTeam.isAlly
+                || oldTeam.isMember != newTeam.isMember
+                || !Objects
+                        .equals(oldTeam.nameComponent.getUnformattedText(), newTeam.nameComponent.getUnformattedText());
     }
 
     public static void addToOwnTeam(int chunkX, int chunkZ) {

--- a/src/main/java/serverutils/net/MessageClaimedChunksModify.java
+++ b/src/main/java/serverutils/net/MessageClaimedChunksModify.java
@@ -8,6 +8,7 @@ import net.minecraft.world.ChunkCoordIntPair;
 import serverutils.ServerUtilities;
 import serverutils.ServerUtilitiesPermissions;
 import serverutils.data.ClaimedChunks;
+import serverutils.handlers.ServerUtilitiesServerEventHandler;
 import serverutils.lib.data.ForgePlayer;
 import serverutils.lib.io.DataIn;
 import serverutils.lib.io.DataOut;
@@ -59,6 +60,10 @@ public class MessageClaimedChunksModify extends MessageToServer {
 
     @Override
     public void onMessage(EntityPlayerMP player) {
+        ServerUtilitiesServerEventHandler.scheduleServerTask(() -> handleMessage(player));
+    }
+
+    private void handleMessage(EntityPlayerMP player) {
         if (!ClaimedChunks.isActive()) {
             return;
         }

--- a/src/main/java/serverutils/net/MessageClaimedChunksRequest.java
+++ b/src/main/java/serverutils/net/MessageClaimedChunksRequest.java
@@ -4,6 +4,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
 
 import serverutils.data.ClaimedChunks;
+import serverutils.handlers.ServerUtilitiesServerEventHandler;
 import serverutils.lib.gui.misc.ChunkSelectorMap;
 import serverutils.lib.io.DataIn;
 import serverutils.lib.io.DataOut;
@@ -47,6 +48,10 @@ public class MessageClaimedChunksRequest extends MessageToServer {
 
     @Override
     public void onMessage(EntityPlayerMP player) {
+        ServerUtilitiesServerEventHandler.scheduleServerTask(() -> handleMessage(player));
+    }
+
+    private void handleMessage(EntityPlayerMP player) {
         if (ClaimedChunks.isActive()) {
             new MessageClaimedChunksUpdate(startX, startZ, player).sendTo(player);
         }

--- a/src/main/java/serverutils/net/MessageNavigatorRequest.java
+++ b/src/main/java/serverutils/net/MessageNavigatorRequest.java
@@ -4,6 +4,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 
 import serverutils.ServerUtilitiesPermissions;
 import serverutils.data.ClaimedChunks;
+import serverutils.handlers.ServerUtilitiesServerEventHandler;
 import serverutils.lib.io.DataIn;
 import serverutils.lib.io.DataOut;
 import serverutils.lib.net.MessageToServer;
@@ -46,6 +47,10 @@ public class MessageNavigatorRequest extends MessageToServer {
 
     @Override
     public void onMessage(EntityPlayerMP player) {
+        ServerUtilitiesServerEventHandler.scheduleServerTask(() -> handleMessage(player));
+    }
+
+    private void handleMessage(EntityPlayerMP player) {
         if (ClaimedChunks.isActive()
                 && PermissionAPI.hasPermission(player, ServerUtilitiesPermissions.CLAIMS_JOURNEYMAP)) {
             new MessageNavigatorUpdate(minX, maxX, minZ, maxZ, player).sendTo(player);

--- a/src/main/java/serverutils/net/MessageNavigatorUpdate.java
+++ b/src/main/java/serverutils/net/MessageNavigatorUpdate.java
@@ -35,43 +35,40 @@ public class MessageNavigatorUpdate extends MessageToClient {
                 .hasPermission(player, ServerUtilitiesPermissions.CLAIMS_JOURNEYMAP_OTHER);
         teams = new Short2ObjectOpenHashMap<>();
 
-        ChunkDimPos pos = new ChunkDimPos();
-        for (int chunkX = minX; chunkX <= maxX; chunkX++) {
-            for (int chunkZ = minZ; chunkZ <= maxZ; chunkZ++) {
-                ClaimedChunk chunk = ClaimedChunks.instance.getChunk(pos.set(chunkX, chunkZ, player.dimension));
-                if (chunk != null) {
-                    ForgeTeam chunkTeam = chunk.getTeam();
+        for (ClaimedChunk chunk : ClaimedChunks.instance.getAllChunks()) {
+            ChunkDimPos pos = chunk.getPos();
+            if (pos.dim != player.dimension || pos.posX < minX || pos.posX > maxX || pos.posZ < minZ || pos.posZ > maxZ)
+                continue;
+            ForgeTeam chunkTeam = chunk.getTeam();
 
-                    if (!chunkTeam.isValid()) {
-                        continue;
-                    }
+            if (!chunkTeam.isValid()) {
+                continue;
+            }
 
-                    if (!canSeeOtherJourneymap && !p.team.equalsTeam(chunkTeam)) {
-                        continue;
-                    }
+            if (!canSeeOtherJourneymap && !p.team.equalsTeam(chunkTeam)) {
+                continue;
+            }
 
-                    ClientClaimedChunks.Team team = teams.get(chunkTeam.getUID());
-                    boolean member = chunkTeam.isMember(p);
-                    int flags = 0;
+            ClientClaimedChunks.Team team = teams.get(chunkTeam.getUID());
+            boolean member = chunkTeam.isMember(p);
+            int flags = 0;
 
-                    if (team == null) {
-                        team = new ClientClaimedChunks.Team(chunkTeam.getUID());
-                        team.color = chunkTeam.getColor();
-                        team.nameComponent = chunkTeam.getTitle();
-                        team.isAlly = chunkTeam.isAlly(p);
-                        team.isMember = member;
-                        teams.put(chunkTeam.getUID(), team);
-                    }
+            if (team == null) {
+                team = new ClientClaimedChunks.Team(chunkTeam.getUID());
+                team.color = chunkTeam.getColor();
+                team.nameComponent = chunkTeam.getTitle();
+                team.isAlly = chunkTeam.isAlly(p);
+                team.isMember = member;
+                teams.put(chunkTeam.getUID(), team);
+            }
 
-                    if (canSeeChunkInfo || member) {
-                        if (chunk.isLoaded()) {
-                            flags = Bits.setFlag(flags, ClientClaimedChunks.ChunkData.LOADED, true);
-                        }
-                    }
-
-                    team.chunkPos.put(chunk.getPos(), new ClientClaimedChunks.ChunkData(team, flags));
+            if (canSeeChunkInfo || member) {
+                if (chunk.isLoaded()) {
+                    flags = Bits.setFlag(flags, ClientClaimedChunks.ChunkData.LOADED, true);
                 }
             }
+
+            team.chunkPos.put(pos, new ClientClaimedChunks.ChunkData(team, flags));
         }
     }
 


### PR DESCRIPTION
## Summary

Use the new changes to Navigator to improve claim overlay rendering
Improve overlay readability by adding dynamic border around claims
Add support for JourneyMap 6, retain full support for JM5 and Xaero

Fix: Optimize requested claim data and move unsafe network-thread reads onto the server thread (various CME risks)

Preview (JM6):
<img width="763" height="605" alt="image" src="https://github.com/user-attachments/assets/21f233be-a464-48c1-9c35-ce690cc1a2cf" />


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)