### PR TITLE
InvSee: Fix row and column order of modded inventories

### DIFF
--- a/src/main/java/serverutils/invsee/InvseeContainer.java
+++ b/src/main/java/serverutils/invsee/InvseeContainer.java
@@ -43,10 +43,16 @@ public class InvseeContainer extends ContainerBase {
 
             List<Slot> inventorySlots = moddedInventorySlots
                     .computeIfAbsent(entry.getKey(), a -> new ArrayList<>(inventory.getSizeInventory()));
+            // the last row is always anchored at the bottom, rows are stacked upwards from there
+            IModdedInventory moddedInventory = entry.getKey();
+            int columns = moddedInventory.getColumns(inventory);
+            int lastRow = (inventory.getSizeInventory() - 1) / columns;
+            boolean bottomUp = moddedInventory.isBottomUpLayout();
             int slotsInRow = 0;
             for (int i = 0; i < inventory.getSizeInventory(); i++) {
-                if (slotsInRow == 9) slotsInRow = 0;
-                Slot slot = entry.getKey().getSlot(player, inventory, i, 8 + slotsInRow++ * 18, 54 - (i / 9) * 18);
+                if (slotsInRow == columns) slotsInRow = 0;
+                int row = bottomUp ? i / columns : lastRow - i / columns;
+                Slot slot = moddedInventory.getSlot(player, inventory, i, 8 + slotsInRow++ * 18, 54 - row * 18);
                 if (slot != null) {
                     inventorySlots.add(slot);
                 } else if (slotsInRow > 0) {

--- a/src/main/java/serverutils/invsee/inventories/AdventureBackpackInv.java
+++ b/src/main/java/serverutils/invsee/inventories/AdventureBackpackInv.java
@@ -48,6 +48,12 @@ public class AdventureBackpackInv implements IModdedInventory {
     }
 
     @Override
+    public int getColumns(IInventory inventory) {
+        // main storage is laid out as 6 rows of 8, the 6 special slots follow it
+        return 8;
+    }
+
+    @Override
     public @NotNull Icon getButtonIcon() {
         if (BACKPACK_ICON == null) {
             BACKPACK_ICON = ItemIcon.getItemIcon(BackpackUtils.createBackpackStack(BackpackTypes.RAINBOW));

--- a/src/main/java/serverutils/invsee/inventories/AdventureBackpackInv.java
+++ b/src/main/java/serverutils/invsee/inventories/AdventureBackpackInv.java
@@ -25,6 +25,9 @@ import serverutils.lib.icon.ItemIcon;
 public class AdventureBackpackInv implements IModdedInventory {
 
     private static final String WEARABLE_TAG = "wearable";
+    // mirrors ContainerBackpack.BACK_INV_COLUMNS, which is private: the main storage is 6 rows of 8, the 6 special
+    // slots follow it
+    private static final int BACK_INV_COLUMNS = 8;
     private static Icon BACKPACK_ICON = null;
 
     @Override
@@ -49,8 +52,7 @@ public class AdventureBackpackInv implements IModdedInventory {
 
     @Override
     public int getColumns(IInventory inventory) {
-        // main storage is laid out as 6 rows of 8, the 6 special slots follow it
-        return 8;
+        return BACK_INV_COLUMNS;
     }
 
     @Override

--- a/src/main/java/serverutils/invsee/inventories/BattlegearInventory.java
+++ b/src/main/java/serverutils/invsee/inventories/BattlegearInventory.java
@@ -69,7 +69,8 @@ public class BattlegearInventory implements IModdedInventory {
             inventorySlot += WEAPON_SETS;
             x += 36;
         }
-        return new WeaponSlotNoPartner(inventory, inventorySlot, x, y - 36 + (index / 2) * 18);
+        // only a handful of the player inventory slots are used, so the grid position is ignored
+        return new WeaponSlotNoPartner(inventory, inventorySlot, x, 18 + (index / 2) * 18);
     }
 
     @Override

--- a/src/main/java/serverutils/invsee/inventories/IModdedInventory.java
+++ b/src/main/java/serverutils/invsee/inventories/IModdedInventory.java
@@ -39,6 +39,20 @@ public interface IModdedInventory {
         return null;
     }
 
+    /**
+     * How many slots the inventory lays out per row in its own gui.
+     */
+    default int getColumns(IInventory inventory) {
+        return 9;
+    }
+
+    /**
+     * Whether slot index 0 belongs to the bottom row instead of the top one, like the player hotbar does.
+     */
+    default boolean isBottomUpLayout() {
+        return false;
+    }
+
     default String getInventoryName() {
         return getButtonText();
     }

--- a/src/main/java/serverutils/invsee/inventories/MainInventory.java
+++ b/src/main/java/serverutils/invsee/inventories/MainInventory.java
@@ -67,6 +67,11 @@ public class MainInventory implements IModdedInventory {
     }
 
     @Override
+    public boolean isBottomUpLayout() {
+        return true;
+    }
+
+    @Override
     public @Nullable Slot getSlot(EntityPlayer player, IInventory inventory, int index, int x, int y) {
         if (index >= inventory.getSizeInventory() - 4) {
             int armorSlot = getArmorSlotIndex(index, inventory);

--- a/src/main/java/serverutils/invsee/inventories/MinecraftBackpackInv.java
+++ b/src/main/java/serverutils/invsee/inventories/MinecraftBackpackInv.java
@@ -5,6 +5,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryBasic;
 import net.minecraft.inventory.Slot;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.StatCollector;
 
 import org.jetbrains.annotations.NotNull;
@@ -36,6 +37,14 @@ public class MinecraftBackpackInv implements IModdedInventory {
     @Override
     public @NotNull IInventory createInventory(EntityPlayer player, int size) {
         return new InventoryBasic("", false, size);
+    }
+
+    @Override
+    public int getColumns(IInventory inventory) {
+        // backpacks that don't fit in 7 rows of 9 get a wider grid, the save only needs the size to tell us how wide
+        BackpackSave save = new BackpackSave(new NBTTagCompound());
+        save.setSize(inventory.getSizeInventory());
+        return save.getSlotsPerRow();
     }
 
     @Override


### PR DESCRIPTION
## Summary
The slot grid was built with the player inventory in mind: rows were laid out bottom to top so the hotbar ends up at the bottom, and MainInventory shuffles its indices to compensate. Every other IModdedInventory inherited that layout without compensating, so their rows were rendered in reverse order.

The row width was hardcoded to 9 as well. Adventure Backpack uses 6 rows of 8 plus 6 special slots, and Backpack Mod widens the grid up to 19 columns once a backpack no longer fits in 7 rows of 9, so both were laid out with the columns shifted.

|BackPack|AdventureBackpack2|
|-|-|
|<img width="384" height="298" alt="java_z2PTGUR97O" src="https://github.com/user-attachments/assets/5d0b3afd-7e06-4560-bbcb-c821f8953ba2" />|<img width="534" height="285" alt="java_IMi0oy1OVs" src="https://github.com/user-attachments/assets/c72e28c4-b4b4-4a79-9724-8fc88d64f85c" />| 

|Before|After|
|-|-|
|<img width="464" height="342" alt="java_UBE4GYgPMs" src="https://github.com/user-attachments/assets/69297cfd-46df-44b6-97ab-fa3579d805da" />|<img width="445" height="360" alt="java_g57vhEmlWO" src="https://github.com/user-attachments/assets/d8094bb0-fde4-4922-91e4-0bf7d28620f8" />|
|<img width="434" height="311" alt="java_AHJy2wNwD0" src="https://github.com/user-attachments/assets/a06537a9-9d46-47f3-942f-845138c25e24" />|<img width="442" height="429" alt="java_pDgd1ROXIj" src="https://github.com/user-attachments/assets/6697adc4-5c9e-4e1e-8502-d45d467257d0" />|


## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
