### PR TITLE
Remove PAUSE_WHEN_EMPTY mixin when ultramine is present

### DIFF
--- a/src/main/java/serverutils/mixin/Mixins.java
+++ b/src/main/java/serverutils/mixin/Mixins.java
@@ -49,6 +49,7 @@ public enum Mixins implements IMixins {
             .addServerMixins(
                     "minecraft.MixinMinecraftServer_PauseWhenEmpty",
                     "minecraft.MixinDedicatedServer_PauseWhenEmpty")
+            .addExcludedMod(TargetedMod.ULTRAMINE)
             .setApplyIf(() -> general.enable_pause_when_empty_property)),
     MAX_TICK_TIME(new MixinBuilder()
             .setPhase(Phase.EARLY)


### PR DESCRIPTION
## Summary
Ultramine has deeply modified DedicatedServer logic unified with a MinecraftServer class. This mixin can't work cuz the necessary `@Shadow` fields can't be found. Trying to fix it from ultramine side is also inefficient, so disabling this to prevent crashes.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
