### PR TITLE
fix modern tab heads with simpleskinbackport 64x64 skins

### DIFF
--- a/src/main/java/serverutils/client/tab/ModernTabRenderer.java
+++ b/src/main/java/serverutils/client/tab/ModernTabRenderer.java
@@ -197,8 +197,13 @@ public class ModernTabRenderer {
                 ResourceLocation skinLoc = TabSkinCache.INSTANCE.getOrLoadSkin(player.name);
                 GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
                 Minecraft.getMinecraft().getTextureManager().bindTexture(skinLoc);
-                Gui.func_152125_a(x, y, 8.0F, 8.0F, 8, 8, HEAD_SIZE, HEAD_SIZE, 64.0F, 32.0F);
-                Gui.func_152125_a(x, y, 40.0F, 8.0F, 8, 8, HEAD_SIZE, HEAD_SIZE, 64.0F, 32.0F);
+                // SimpleSkinBackport uploads 64x64; steve fallback is still 64x32
+                int texW = GL11.glGetTexLevelParameteri(GL11.GL_TEXTURE_2D, 0, GL11.GL_TEXTURE_WIDTH);
+                int texH = GL11.glGetTexLevelParameteri(GL11.GL_TEXTURE_2D, 0, GL11.GL_TEXTURE_HEIGHT);
+                float tileW = texW >= 64 ? texW : 64.0F;
+                float tileH = texH >= 32 ? texH : 32.0F;
+                Gui.func_152125_a(x, y, 8.0F, 8.0F, 8, 8, HEAD_SIZE, HEAD_SIZE, tileW, tileH);
+                Gui.func_152125_a(x, y, 40.0F, 8.0F, 8, 8, HEAD_SIZE, HEAD_SIZE, tileW, tileH);
                 textX += HEAD_PADDING;
             }
 

--- a/src/main/java/serverutils/client/tab/TabSkinCache.java
+++ b/src/main/java/serverutils/client/tab/TabSkinCache.java
@@ -5,7 +5,9 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
 
 public class TabSkinCache {
@@ -17,6 +19,18 @@ public class TabSkinCache {
     private TabSkinCache() {}
 
     public ResourceLocation getOrLoadSkin(String playerName) {
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.theWorld != null) {
+            EntityPlayer entity = mc.theWorld.getPlayerEntityByName(playerName);
+            if (entity instanceof AbstractClientPlayer acp) {
+                ResourceLocation live = acp.getLocationSkin();
+                if (live != null) {
+                    cache.put(playerName, live);
+                    return live;
+                }
+            }
+        }
+
         ResourceLocation loc = cache.get(playerName);
         if (loc == null) {
             loc = AbstractClientPlayer.getLocationSkin(playerName);


### PR DESCRIPTION
## Summary
modern tab heads were hardcoded as 64x32. simpleskinbackport already converts getDownloadImageSkin to 64x64 (https://github.com/GTNewHorizons/SimpleSkinBackport/pull/3) so in full pack you get a black square. (eg : 
<img width="1725" height="439" alt="image" src="https://github.com/user-attachments/assets/53b5f91a-50d9-4403-8b19-c4a5036f856f" />
to : 
<img width="1579" height="592" alt="image" src="https://github.com/user-attachments/assets/f32d3e64-0f93-4ca0-9cf2-bf3315759ad9" />

- sample the bound texture size so 64x64 and steve 64x32 both hit the face 
- if the player is in the world, use that skin instead of a second download 

tested on daily 715 with current branch.


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
